### PR TITLE
chore: 配置 Dependabot（npm + GitHub Actions）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # 应用依赖与开发依赖
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions 版本升级
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 背景

仓库缺少自动化依赖更新，Electron 生态迭代快，安全补丁不应该靠手动盯。

## 改动

- 新增 `.github/dependabot.yml`
- npm 依赖：每周检查，minor/patch 打包成一组 PR（控制噪音），上限 5 个
- GitHub Actions：每周检查版本升级，上限 5 个

## 生效说明

合并后 Dependabot 会先跑一轮全量扫描，首次可能集中出现几个 PR，属于预期现象。