### PR TITLE
chore: 重写 issue 模板，替换 electron-react-boilerplate 残留

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -1,67 +1,42 @@
+name: 🐞 Bug report
+about: 遇到了技术问题？在这里反馈
+labels: ['bug']
 ---
-name: Bug report
-about: You're having technical issues. 🐞
-labels: 'bug'
----
 
-<!-- Please use the following issue template or your issue will be closed -->
+<!-- 请尽量填写以下模板，信息越完整，问题越容易被定位和修复 -->
 
-## Prerequisites
+## 问题描述
 
-<!-- If the following boxes are not ALL checked, your issue is likely to be closed -->
+<!-- 发生了什么？期望发生什么？ -->
 
-- [ ] Using npm
-- [ ] Using an up-to-date [`main` branch](https://github.com/electron-react-boilerplate/electron-react-boilerplate/tree/main)
-- [ ] Using latest version of devtools. [Check the docs for how to update](https://electron-react-boilerplate.js.org/docs/dev-tools/)
-- [ ] Tried solutions mentioned in [#400](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/400)
-- [ ] For issue in production release, add devtools output of `DEBUG_PROD=true npm run build && npm start`
-
-## Expected Behavior
-
-<!--- What should have happened? -->
-
-## Current Behavior
-
-<!--- What went wrong? -->
-
-## Steps to Reproduce
-
-<!-- Add relevant code and/or a live example -->
-<!-- Add stack traces -->
+## 复现步骤
 
 1.
-
 2.
 
-3.
+## 运行环境
 
-4.
+<!-- 以下信息可在「设置 → 关于」或日志文件中找到，完整日志路径见文末 -->
 
-## Possible Solution (Not obligatory)
+- DashPlayer 版本：
+- 安装包类型：exe / msi / dmg / deb / rpm
+- 操作系统及版本：
+- 是否从旧版本升级而来：是 / 否（旧版本号：）
 
-<!--- Suggest a reason for the bug or how to fix it. -->
+## 日志
 
-## Context
+<!-- 应用内日志目录：设置 → 存储设置 中可以打开日志所在文件夹 -->
 
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-<!--- Did you make any changes to the boilerplate after cloning it? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<details><summary>日志内容（可折叠长日志）</summary>
 
-## Your Environment
+```
+在此粘贴相关日志片段
+```
 
-<!--- Include as many relevant details about the environment you experienced the bug in -->
+</details>
 
-- Node version :
-- electron-react-boilerplate version or branch :
-- Operating System and version :
-- Link to your project :
+## 补充信息
 
-<!---
-❗️❗️ Also, please consider donating (https://opencollective.com/electron-react-boilerplate-594) ❗️❗️
+截图、视频或其他有助于定位问题的材料。
 
-Donations will ensure the following:
-
-🔨 Long term maintenance of the project
-🛣 Progress on the roadmap
-🐛 Quick responses to bug reports and help requests
- -->
+> 安装遇到问题？请先阅读[安装指南（含常见安装失败排查）](https://solidspoon.xyz/DashPlayer/installation.html)。

--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -1,3 +1,4 @@
+---
 name: 🐞 Bug report
 about: 遇到了技术问题？在这里反馈
 labels: ['bug']
@@ -25,7 +26,7 @@ labels: ['bug']
 
 ## 日志
 
-<!-- 应用内日志目录：设置 → 存储设置 中可以打开日志所在文件夹 -->
+<!-- 日志目录在应用数据目录下的 logs 文件夹：Windows %APPDATA%\DashPlayer\logs；macOS ~/Library/Application Support/DashPlayer/logs；Linux ~/.config/DashPlayer/logs -->
 
 <details><summary>日志内容（可折叠长日志）</summary>
 

--- a/.github/ISSUE_TEMPLATE/2-Question.md
+++ b/.github/ISSUE_TEMPLATE/2-Question.md
@@ -1,19 +1,10 @@
+name: ❓ Question
+about: 使用上遇到疑问？在这里提问
+labels: ['question']
 ---
-name: Question
-about: Ask a question.❓
-labels: 'question'
----
 
-## Summary
+## 问题
 
-<!-- What do you need help with? -->
+<!-- 想了解什么？ -->
 
-<!---
-❗️❗️ Also, please consider donating (https://opencollective.com/electron-react-boilerplate-594) ❗️❗️
-
-Donations will ensure the following:
-
-🔨 Long term maintenance of the project
-🛣 Progress on the roadmap
-🐛 Quick responses to bug reports and help requests
- -->
+<!-- 使用问题也可以先查阅文档：https://solidspoon.xyz/DashPlayer/ -->

--- a/.github/ISSUE_TEMPLATE/2-Question.md
+++ b/.github/ISSUE_TEMPLATE/2-Question.md
@@ -1,3 +1,4 @@
+---
 name: ❓ Question
 about: 使用上遇到疑问？在这里提问
 labels: ['question']

--- a/.github/ISSUE_TEMPLATE/3-Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3-Feature_request.md
@@ -1,15 +1,16 @@
+name: 💡 Feature request
+about: 希望增加某个功能
+labels: ['enhancement']
 ---
-name: Feature request
-about: You want something added to the boilerplate. 🎉
-labels: 'enhancement'
----
 
-<!---
-❗️❗️ Also, please consider donating (https://opencollective.com/electron-react-boilerplate-594) ❗️❗️
+## 想要解决的问题或需求
 
-Donations will ensure the following:
+<!-- 描述你希望达成的目标，而不是仅仅描述功能本身 -->
 
-🔨 Long term maintenance of the project
-🛣 Progress on the roadmap
-🐛 Quick responses to bug reports and help requests
- -->
+## 期望的方案
+
+<!-- 如果对实现方式有想法可以写在这里，没有也没关系 -->
+
+## 替代方案
+
+<!-- 目前你是用什么变通方式解决这个问题的？ -->

--- a/.github/ISSUE_TEMPLATE/3-Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3-Feature_request.md
@@ -1,3 +1,4 @@
+---
 name: 💡 Feature request
 about: 希望增加某个功能
 labels: ['enhancement']

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,8 @@
+# Config support for issue templates
+
+blank_issues_enabled: false
+contact_links: []
+
 requiredHeaders:
-  - Prerequisites
-  - Expected Behavior
-  - Current Behavior
-  - Possible Solution
-  - Your Environment
+  - 问题描述
+  - 运行环境

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,7 +2,3 @@
 
 blank_issues_enabled: false
 contact_links: []
-
-requiredHeaders:
-  - 问题描述
-  - 运行环境


### PR DESCRIPTION
## 背景

现有 issue 模板仍是 electron-react-boilerplate 的原版残留：让用户勾选 "Using npm"、报告 "electron-react-boilerplate version"、引用 ERB 的 issue #400、带 OpenCollective 捐赠文案。实际用户（如 #189）完全不按模板填写，模板已失去引导作用。

## 改动

- **Bug report**：改为「问题描述 / 复现步骤 / 运行环境 / 日志 / 补充信息」结构
  - 运行环境要求填写 DashPlayer 版本、安装包类型（exe/msi/dmg/deb/rpm）、是否升级安装——这些都是定位安装类问题的关键信息
  - 日志区使用折叠块，避免刷屏
  - 文末链接到文档站安装指南（含安装失败排查）
- **Question / Feature request**：精简为轻量结构，移除捐赠文案
- **config.yml**：`requiredHeaders` 同步改为新模板的中文标题

## 关联

#189 反馈的安装问题排查中暴露：模板没有引导用户提供版本/安装包类型/日志，导致排查多一轮往返。