### PR TITLE
fix(ci): release-please 改用纯版本号 tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "packages": {
-    ".": {}
+    ".": {
+      "include-component-in-tag": false
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Release Please 默认按包名生成 `dash-player-v6.x.x` 格式的 tag，与本仓库既有的 `v6.x.x` tag 不匹配，导致找不到上个发版基线，changelog 把 2026 年 2 月以来的全部提交都算了进去（见 #195）
- 加 `include-component-in-tag: false`，让它识别既有的 `v6.6.0` tag 作为基线，只攒之后的提交

## Test plan
- [ ] 合并本 PR 后，Release Please 重新运行，新发的发版 PR 中 changelog 只包含 v6.6.0（2026-08-30）之后的提交
- [ ] 合并发版 PR 后产生的 tag 为 `v6.7.0` 格式

## 后续
- #195 是按错误基线攒出来的，等本 PR 合并、新的发版 PR 生成后应关闭 #195 并删除其分支