### PR TITLE
fix(log): 周报问题修复——日志降噪、转录收尾、Error 证据与两处坏味道

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -88,7 +88,7 @@ preload 每次 `invoke` 生成一个 trace id，main 在 `registerRoute` 边界�
 | `FfmpegServiceImpl` | main | 只记录网关看不到的任务体异常（`ffmpeg task failed`，含 `job`）；子进程失败与取消不在这里重复 |
 | `FfmpegGatewayImpl` | main | `spawned ffmpeg`（`job`/`pid`/`command`）、`FFmpeg 执行完成`、`FFmpeg 执行失败`（error，含 `exitCode`/`pid`/`stderrTail`）、`FFmpeg 已取消`（info）——子进程维度的唯一证据点 |
 | `SherpaOnnx` / `SherpaTts` | main | 识别/合成子进程启停与异常退出：`spawned sherpa-onnx`、`sherpa-onnx exited abnormally`、`sherpa-onnx output rejected`、`sherpa-onnx cancelled` |
-| `LocalTranscriptionService` | main | `transcription started`、分段识别重试与耗尽 |
+| `LocalTranscriptionService` | main | `transcription started`、分段识别重试与耗尽、`transcription done`/`transcription cancelled`/`transcription failed` 任务收尾（含 `elapsedMs`，done 另带 `chunkCount`/`srtPath`）——`job` 首尾成对靠这三条收尾闭环 |
 | `VideoLearningServiceImpl` | main | `clip trim started` / `clip ready` / 片段任务失败 |
 | `concurrency` | main | 信号量/限流等待与持锁超阈值（见第 4 节） |
 | `GlobalError` | renderer | `uncaught exception`、`unhandled rejection`、`resource load failed` |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -46,7 +46,7 @@ du -sh "$HOME/Library/Application Support/DashPlayer/logs-dev"
 
 - 递归深度 ≤ 5，对象键数 ≤ 50（超出记 `__truncatedKeys`），数组长度 ≤ 50（超出追加 `"[Truncated N items]"`）；
 - **字符串超过 4000 字符是"保头丢尾"**，而 ffmpeg/sherpa 的致命错误恰恰在输出末尾；
-- `Error` 序列化为 `{ name, message, stack, cause }`；命中敏感键名的值替换为 `***`。
+- `Error` 序列化为 `{ name, message, stack, cause }`，若错误对象自带 `statusCode`/`responseBody`（AI SDK 等第三方错误的 upstream 证据）会一并保留；命中敏感键名的值替换为 `***`。
 
 由此得出一条硬约束：**可能很长的文本必须以"行数组"入 `data`**，例如 `stderrTail: string[]`。这样尾部关键行是若干独立短字段，不会被整体截断。
 

--- a/src/backend/infrastructure/logger/simple-logger.ts
+++ b/src/backend/infrastructure/logger/simple-logger.ts
@@ -372,11 +372,16 @@ function sanitizeValue(value: unknown, depth = 0, seen = new WeakSet<object>()):
             return '[Circular Error]';
         }
         seen.add(value);
+        // AI SDK 等第三方错误把上游 HTTP 状态与响应体放在自有属性上，
+        // 白名单外的关键归因证据，不存在时保持字段缺省。
+        const enriched = value as Error & { statusCode?: unknown; responseBody?: unknown };
         return {
             name: value.name,
             message: sanitizeValue(value.message, depth + 1, seen),
             stack: sanitizeValue(value.stack, depth + 1, seen),
             cause: sanitizeValue(value.cause, depth + 1, seen),
+            ...(enriched.statusCode !== undefined && { statusCode: sanitizeValue(enriched.statusCode, depth + 1, seen) }),
+            ...(enriched.responseBody !== undefined && { responseBody: sanitizeValue(enriched.responseBody, depth + 1, seen) }),
         };
     }
     if (typeof value !== 'object') {

--- a/src/backend/infrastructure/renderer/RendererGatewayImpl.ts
+++ b/src/backend/infrastructure/renderer/RendererGatewayImpl.ts
@@ -55,7 +55,9 @@ export default class RendererGatewayImpl implements RendererGateway {
                 settled = true;
                 clearTimeout(timeoutId);
                 ipcMain.removeListener(eventName, responseListener);
-                this.logger[outcome === 'succeeded' ? 'info' : 'warn']('renderer api call settled', {
+                // 成功路径是常规节奏（翻译回推等高频推送都走这里），只留 debug；
+                // failed/timed-out 是需要解释的现象，保持 warn。
+                this.logger[outcome === 'succeeded' ? 'debug' : 'warn']('renderer api call settled', {
                     path,
                     callId,
                     outcome,
@@ -84,7 +86,7 @@ export default class RendererGatewayImpl implements RendererGateway {
             }, RENDERER_API_RESPONSE_TIMEOUT_MS);
 
             ipcMain.once(eventName, responseListener);
-            this.logger.info('renderer api call dispatched', {
+            this.logger.debug('renderer api call dispatched', {
                 path,
                 callId,
                 webContentsId: mainWindow.webContents.id,

--- a/src/backend/services/ChatSessionService.ts
+++ b/src/backend/services/ChatSessionService.ts
@@ -16,6 +16,7 @@ import type { ChatReasoningEffort } from '@/common/types/chat';
 import { AnalysisStartParams, AnalysisStartResult, DeepPartial } from '@/common/types/analysis';
 import { AiUnifiedAnalysisRes, AiUnifiedAnalysisSchema } from '@/common/types/aiRes/AiUnifiedAnalysisRes';
 import { WithRateLimit } from '@/backend/utils/concurrency/decorators';
+import { isUserCancellation } from '@/common/utils/cancellation';
 import {
     appendBackgroundMessage,
     buildAnalysisPrompt,
@@ -522,13 +523,14 @@ export class ChatSessionServiceImpl implements ChatSessionService {
     }
 
     /**
-     * 判断异常是否由 AbortSignal 主动取消产生。
+     * 判断异常是否由用户主动取消产生。
+     *
+     * 统一走 common 的类型名判定：消息正则会把恰好含 "closed" 等字样的真实故障误判为取消并降级。
      * @param error 捕获到的异常。
      * @returns 属于取消语义时为 true。
      */
     private isCancellation(error: unknown): boolean {
-        return error instanceof Error
-            && (error.name === 'AbortError' || /abort|cancel|closed/i.test(error.message));
+        return isUserCancellation(error);
     }
 
     private normalizeAnalysisPartial(

--- a/src/backend/services/TranscriptionService.ts
+++ b/src/backend/services/TranscriptionService.ts
@@ -299,22 +299,32 @@ export class LocalTranscriptionServiceImpl implements TranscriptionService {
             throw error;
         }
 
+        let executionStartedAt: number | null = null;
         concurrency.withMutex('transcription', async () => {
             // 若在排队等待期间被取消，不再执行转录。
             if (controller.signal.aborted) {
                 throw new CancelByUserError('Transcription cancelled by user');
             }
             this.activeFilePath = normalizedFilePath;
+            executionStartedAt = Date.now();
             await this.doTranscribe(normalizedFilePath, controller.signal);
         }, { signal: controller.signal }).catch(async (error) => {
+            const job = transcriptionJob(normalizedFilePath);
+            const elapsedMs = executionStartedAt !== null ? Date.now() - executionStartedAt : 0;
             // 在队列等待或实际执行期间取消，都统一持久化为 cancelled。
             if (controller.signal.aborted) {
+                this.logger.info('transcription cancelled', { job, elapsedMs });
                 await this.sendProgress(0, normalizedFilePath, TranscriptTaskState.CANCELLED, 0, {
                     message: '转录任务已取消',
                 });
                 throw new CancelByUserError('Transcription cancelled by user');
             }
 
+            this.logger.error('transcription failed', {
+                job,
+                elapsedMs,
+                error: error instanceof Error ? error.message : String(error),
+            });
             await this.sendProgress(0, normalizedFilePath, TranscriptTaskState.FAILED, 0, {
                 error: error instanceof Error ? error.message : String(error),
             });
@@ -408,6 +418,7 @@ export class LocalTranscriptionServiceImpl implements TranscriptionService {
     private async transcribeWithSherpaOnnx(opts: { filePath: string; tempFolder: string; signal: AbortSignal }): Promise<void> {
         const { filePath, tempFolder, signal } = opts;
         const job = transcriptionJob(filePath);
+        const startedAt = Date.now();
         const modelsRoot = await this.storageDirectoryProvider.provideDirectory(StorageDirectoryTarget.MODELS);
         await this.sendProgress(0, filePath, TranscriptTaskState.IN_PROGRESS, 0, { phase: 'preparing' });
         if (signal.aborted) throw new CancelByUserError('Transcription cancelled by user');
@@ -514,6 +525,12 @@ export class LocalTranscriptionServiceImpl implements TranscriptionService {
         await this.fileSystemGateway.writeTextFile(srtFileName, finalSrt);
 
         await this.sendProgress(0, filePath, TranscriptTaskState.DONE, 100, { srtPath: srtFileName });
+        this.logger.info('transcription done', {
+            job,
+            elapsedMs: Date.now() - startedAt,
+            chunkCount: ranges.length,
+            srtPath: srtFileName,
+        });
         this.sessions.delete(filePath);
     }
 

--- a/src/backend/services/subtitle-translation/SubtitleTranslationService.ts
+++ b/src/backend/services/subtitle-translation/SubtitleTranslationService.ts
@@ -801,6 +801,7 @@ export class SubtitleTranslationServiceImpl implements SubtitleTranslationServic
     /**
      * 使用腾讯接口翻译不属于播放窗口的独立文本批次。
      *
+     * 与主路径 {@link translateWithTencent} 一致走 `tencent` 限流，避免直翻批次绕过配额触发上游限流。
      * @param targets 使用归一化原文作为 key 的目标条目。
      * @param batchId 日志关联批次编号。
      * @returns 归一化原文到翻译结果的映射。
@@ -814,13 +815,13 @@ export class SubtitleTranslationServiceImpl implements SubtitleTranslationServic
             throw new Error('腾讯翻译客户端未初始化，请检查密钥配置');
         }
 
-        const holder = await client.batchTrans(
+        const holder = await concurrency.withRateLimit('tencent', () => client.batchTrans(
             targets.map((target) => target.text),
             {
                 batchId,
                 fileHash: 'direct',
             }
-        );
+        ));
         const translations = new Map<string, string>();
         targets.forEach((target) => {
             const translation = holder.get(target.text)?.trim();

--- a/src/fronted/app/bootstrap/initRendererApis.ts
+++ b/src/fronted/app/bootstrap/initRendererApis.ts
@@ -54,15 +54,7 @@ export function initRendererApis(): () => void {
     });
 
     register('translation/batch-result', async (params) => {
-        // 字幕批次只回推最终结果，日志不记录完整译文。
-        logger.info('字幕翻译回推已到达 renderer handler', {
-            count: params.translations.length,
-            fileHashes: Array.from(new Set(params.translations.map((item) => item.fileHash))),
-        });
         useTranslation.getState().updateTranslations(params.translations);
-        logger.info('字幕翻译回推已写入状态仓库', {
-            count: params.translations.length,
-        });
     });
 
     register('transcript/batch-result', async (params) => {

--- a/src/fronted/features/player/hooks/usePlayerBridge.ts
+++ b/src/fronted/features/player/hooks/usePlayerBridge.ts
@@ -256,10 +256,16 @@ export function usePlayerBridge(navigate: (path: string) => void) {
         };
     }, [videoId]);
 
+    /**
+     * ReactPlayer onReady 回调：恢复播放进度并把视频标记为已加载。
+     *
+     * onReady 在每次 seek/缓冲完成后都会重放（训练模式连续 seek 时可达每秒数次），
+     * 靠 lastLoadedFileRef 幂等去重；守卫命中是常规路径，只在 debug 级留下痕迹。
+     */
     const handlePlayerReady = useCallback(async () => {
         const file = useFile.getState().videoPath;
         const currentVideoId = useFile.getState().videoId;
-        logger.info('player ready callback entered', {
+        logger.debug('player ready callback entered', {
             videoId: currentVideoId,
             videoPath: file,
             lastLoadedFile: lastLoadedFileRef.current,
@@ -273,10 +279,6 @@ export function usePlayerBridge(navigate: (path: string) => void) {
             return;
         }
         if (lastLoadedFileRef.current === file) {
-            logger.warn('player ready callback skipped: file already loaded', {
-                videoId: currentVideoId,
-                videoPath: file,
-            });
             return;
         }
         try {

--- a/src/fronted/features/player/hooks/usePlayerBridge.ts
+++ b/src/fronted/features/player/hooks/usePlayerBridge.ts
@@ -151,7 +151,13 @@ export function usePlayerBridge(navigate: (path: string) => void) {
             const bucket = Math.floor(position / demandGranularity);
             if (bucket === lastReportedBucket) return;
             lastReportedBucket = bucket;
-            void transcriptApi.updateDemand(videoPath!, position).catch(() => undefined);
+            void transcriptApi.updateDemand(videoPath!, position).catch((error) => {
+                logger.warn('failed to update transcription demand', {
+                    videoPath,
+                    position,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            });
         };
         const timer = window.setInterval(reportDemand, 2000);
         return () => window.clearInterval(timer);

--- a/src/fronted/features/player/translationStore.ts
+++ b/src/fronted/features/player/translationStore.ts
@@ -179,7 +179,7 @@ const useTranslation = create(
                 }
                 const demandId = nextSubtitleDemandId;
                 nextSubtitleDemandId += 1;
-                logger.info('subtitle translation request sent', {
+                logger.debug('subtitle translation request sent', {
                     fileHash: target.fileHash,
                     currentIndex: target.currentIndex,
                     demandId,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,7 +5,7 @@ import {RuntimeSettingKey} from './common/contracts/runtime-settings';
 import {ApiDefinitions, ApiMap} from '@/common/api/api-def';
 import {DpTask} from '@/common/contracts/dp-task';
 import {RendererApiDefinitions, RendererApiMap} from '@/common/api/renderer-api-def';
-import type { SimpleEvent, TraceCarrier } from '@/common/log/simple-types';
+import type { TraceCarrier } from '@/common/log/simple-types';
 
 export type Channels =
     | 'main-state'
@@ -30,23 +30,6 @@ const on = (channel: Channels, func: (...args: unknown[]) => void) => {
 const createTraceCarrier = (): TraceCarrier => ({
     traceId: globalThis.crypto.randomUUID().replaceAll('-', ''),
 });
-
-/**
- * 记录字幕翻译回推在 preload 中的收发状态，避免记录译文正文。
- *
- * @param message 生命周期事件名称。
- * @param data 仅包含调用标识、路径、数量和耗时的上下文。
- */
-const writeTranslationRendererApiLog = (message: string, data: Record<string, unknown>): void => {
-    ipcRenderer.send('dp-log/write', {
-        ts: new Date().toISOString(),
-        level: 'info',
-        process: 'renderer',
-        module: 'RendererApiPreload',
-        msg: message,
-        data,
-    } satisfies SimpleEvent);
-};
 
 const electronHandler = {
     onStoreUpdate: (func: (key: RuntimeSettingKey, value: string) => void) => {
@@ -77,43 +60,14 @@ const electronHandler = {
         handler: RendererApiMap[K]
     ): () => void {
         const listener = async (event: IpcRendererEvent, callId: string, params: RendererApiDefinitions[K]['params']) => {
-            const isTranslationBatch = path === 'translation/batch-result';
-            const startedAt = Date.now();
-            const translationCount = isTranslationBatch
-                ? (params as RendererApiDefinitions['translation/batch-result']['params']).translations.length
-                : undefined;
-            if (isTranslationBatch) {
-                writeTranslationRendererApiLog('字幕翻译回推已到达 preload', {
-                    path,
-                    callId,
-                    translationCount,
-                });
-            }
             try {
                 const result = await handler(params);
                 ipcRenderer.send(`renderer-api-response-${callId}`, { success: true, result });
-                if (isTranslationBatch) {
-                    writeTranslationRendererApiLog('字幕翻译回推已由 preload 确认', {
-                        path,
-                        callId,
-                        translationCount,
-                        elapsedMs: Date.now() - startedAt,
-                    });
-                }
             } catch (error) {
                 ipcRenderer.send(`renderer-api-response-${callId}`, {
                     success: false,
                     error: error instanceof Error ? error.message : String(error)
                 });
-                if (isTranslationBatch) {
-                    writeTranslationRendererApiLog('字幕翻译回推 handler 失败', {
-                        path,
-                        callId,
-                        translationCount,
-                        elapsedMs: Date.now() - startedAt,
-                        error: error instanceof Error ? error.message : String(error),
-                    });
-                }
             }
         };
 


### PR DESCRIPTION
## 背景

2026-09-04 首次周度健康巡检发现的问题修复（对应周报 P2/P3/P4 项，投入产出比最高的 1~6、8 号动作）。预计消掉约 31% 的周日志体量，并补齐三处证据链缺口。

## 改动清单

**降噪（P3-1/2/3，约 31% 周体量）**
- `usePlayerBridge` ready 回调：entered 降 debug，删除守卫命中 warn——ReactPlayer onReady 每次 seek 后重放属常规路径，单会话曾刷 424 次
- 字幕翻译回推链路：删 preload 单通道特判日志与 renderer handler 两条 info；RendererGateway dispatched/settled 成功路径降 debug（failed/timed-out 保持 warn）
- 逐句 `subtitle translation request sent` 降 debug

**证据链缺口**
- 转录任务补 `transcription done/cancelled/failed` 收尾日志（含 elapsedMs；done 另带 chunkCount/srtPath）——修复 job 首尾成对契约，此前 46 个分块跑完查不到任何结局记录
- Error 序列化保留 `statusCode`/`responseBody`——AI SDK 异常的上游拒绝原因不再丢失，下次 400 可直接归因
- `updateDemand` 上报失败补 warn，不再静默吞掉

**坏味道**
- 聊天取消判定统一走 `isUserCancellation`（类型名），删除消息正则——避免把含 "closed" 的真实故障误判为取消
- 收藏片段直翻腾讯补 `withRateLimit('tencent')`，对齐主路径

**文档**
- `docs/observability.md` 同步两处契约：Error 序列化字段、LocalTranscriptionService 收尾日志

## 验证

- `yarn lint`：改动文件零新增告警（仓库既有 5 error 均在未触碰文件）
- `yarn test:run`（ELECTRON_RUN_AS_NODE）：24 个文件全过，168 passed / 10 skipped，含 usePlayerBridge 既有测试
- 无 drizzle 迁移，无需重新 `yarn run download`

## 不在本 PR

- 收藏单词 400（P1-1）：待 Error 序列化修复上线后用新日志归因，或手动确认词典模型对 `reasoning` 参数的支持
- VocabularyService 分层重构（P4-4）：单独立项