### PR TITLE
fix(ci): 发版构建改为 workflow_call 链式调用

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,10 @@
 name: Release Please
 
 # 监听 main 分支：合并功能 PR 后，由 Release Please 根据提交信息攒"发版 PR"
-# （内含版本号 bump 与 CHANGELOG 更新）；合并发版 PR 后自动打 tag 并创建 GitHub Release，
-# tag 推送会触发 release.yml 的四平台构建，产物自动挂到该 Release 上。
+# （内含版本号 bump 与 CHANGELOG 更新）；合并发版 PR 后自动打 tag 并创建 GitHub Release。
+# 注意：Release Please 用 GITHUB_TOKEN 打 tag，GitHub 规定此类事件不会触发其他 workflow，
+# 所以四平台构建通过下方 build job 以 workflow_call 方式在同一运行内直接链式调用，
+# 而不是依赖 release.yml 的 tag 触发器。
 on:
   push:
     branches: [main]
@@ -13,10 +15,22 @@ permissions:
 
 jobs:
   release-please:
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # 发版 PR 合并（release_created 为 true）时，直接调用 release.yml 执行四平台构建；
+  # 构建上下文即本次 push 的 main 提交（发版 PR 的合并结果，与 tag 内容一致）。
+  build:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22.12.0
+          node-version: 22.x
           cache: yarn
       - name: Install WiX Toolset (Windows only)
         if: matrix.os.name == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@
 name: Release app
 on:
   workflow_dispatch:
+  # 供 release-please.yml 在发版 PR 合并后以 workflow_call 直接调用
+  # （GITHUB_TOKEN 打的 tag 不会触发 push 事件，不能只靠下面的 tag 触发器）
+  workflow_call:
   push:
     tags: ['v*']
 permissions:


### PR DESCRIPTION
## 背景

v6.7.0 发版时 Release 创建了但安装包没构建。原因：Release Please 用 `GITHUB_TOKEN` 打 tag，而 GitHub 规定 `GITHUB_TOKEN` 触发的事件不会级联触发其他 workflow，所以 release.yml 的 tag 触发器收不到通知。

## 改动

- `release-please.yml`：新增 `build` job，在 `release_created`（即发版 PR 被合并）时以 `workflow_call` 直接调用 release.yml，四平台构建在同一事件链内完成
- `release.yml`：`on:` 增加 `workflow_call` 触发器；tag 触发和 workflow_dispatch 保留（手动补构建、回滚重发时用）

## Test plan

- [ ] 合并本 PR 后，合入一个 `feat:`/`fix:` 提交让 Release Please 攒出下一个发版 PR，合并它，确认 Release app 四平台构建自动运行且产物挂到新 Release
- [ ] v6.7.0 的安装包需手动补：Actions → Release app → Run workflow → 选 tag v6.7.0（待本 PR 合并后执行）

## 验证说明

无法在不真正发一版的情况下端到端验证 workflow_call 链路，需按上面第一项在下次发版时确认。