### PR TITLE
fix(ci): 构建进程放宽 Node 堆上限，防 Vite 构建 OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,13 @@ jobs:
         if: matrix.os.name != 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 主进程 bundle 已大过 V8 默认 ~2GB 堆上限，构建时 OOM（v6.7.0 arm64 dmg 缺失的直接原因）
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run publish
       - name: Publish app with Visual Studio (Windows only)
         if: matrix.os.name == 'windows'
         shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=4096
         run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 && npm run publish


### PR DESCRIPTION
## 背景

v6.7.0 发版时 macOS arm64 任务里 Vite 构建 `src/main.ts` 报 `FATAL ERROR: Reached heap limit`（Node 堆到 ~2GB 上限后 OOM）。forge 的 vite 插件未将子进程崩溃视为失败，任务标绿照常发布，导致 Release 缺 arm64 dmg。主进程 bundle 已大过 V8 默认堆上限（升级 Node 22.23 后暴露）。

## 改动

- release.yml 两个 Publish 步骤加 `NODE_OPTIONS: --max-old-space-size=4096`（runner 有 7GB 内存，4GB 上限安全）

## Test plan

- [x] 合并本 PR 后，用 tag `v6.7.0` 重新触发 "Release app"，确认四个平台产物齐全（重点：arm64 dmg），已有同名产物被覆盖更新
- [x] 观察下次正常发版链路（workflow_call）同样出齐产物

## 后续隐患（不在本 PR 范围）

forge vite 插件吞掉构建子进程崩溃导致 CI 假绿，本次靠修 OOM 消除触发条件；是否加产物齐全性校验待议。