### PR TITLE
fix: 结构化输出提示词补充 JSON 字样，修复收藏单词报错

### DIFF
--- a/src/backend/services/VocabularyService.ts
+++ b/src/backend/services/VocabularyService.ts
@@ -589,7 +589,9 @@ export class VocabularyServiceImpl implements VocabularyService {
             '1. 覆盖该词最常用的 1-3 个含义；',
             '2. 每个义项以词性缩写开头（如 n.、v.、adj. 等），义项之间用中文分号分隔；',
             '3. 总长度不超过 60 个字，语言精炼，不要例句，不要额外解释；',
-            '4. 结果放入 translate 字段。'
+            // 提示词必须出现 "JSON" 字样：json_object 模式下部分兼容端点（如 uniapi 的
+            // deepseek-v4-flash）会校验这一点，缺失时直接 400，收藏单词整体失败。
+            '4. 以 JSON 格式输出，结果放入 translate 字段。'
         ].join('\n');
     }
 

--- a/src/common/types/aiRes/AiFuncFormatSplit.ts
+++ b/src/common/types/aiRes/AiFuncFormatSplit.ts
@@ -21,7 +21,7 @@ export const buildFormatSplitPrompt = (text: string): string => codeBlock`
     待修正的用户文本：
     ${text}
 
-    请直接输出修正后的文本内容，不要包含 markdown 代码块包裹、额外解释或无关问候。
+    请以 JSON 格式输出修正后的文本，结果放入 formatedText 字段，不要包含 markdown 代码块包裹、额外解释或无关问候。
 `;
 
 export class AiFuncFormatSplitPrompt {


### PR DESCRIPTION
## 背景

开发环境日志中出现连续多次 `收藏单词失败`（VocabularyServiceImpl，单词 "down"），上游 uniapi 返回 400 / code 10305。

排查结论（日志 + 抓包 + 最小复现均已验证）：

- `Output.object` 结构化输出走 `response_format: {"type":"json_object"}`，该模式要求**提示词中必须出现 "JSON" 字样**，否则部分兼容端点（如 uniapi 的 `deepseek-v4-flash`）直接 400。
- 收藏单词的释义提示词（`VocabularyService.buildDefinitionPrompt`）不含 "JSON"，切到该模型后收藏新单词必失败；已存在的单词不走 AI，所以此前未暴露。
- 同样问题的还有分章文本修正提示词（`AiFuncFormatSplitPrompt`）；词典弹窗、整句分析、字幕翻译的提示词已自带 "JSON" 字样，不受影响。

## 改动

- `VocabularyService.buildDefinitionPrompt`：输出要求改为“以 JSON 格式输出，结果放入 translate 字段”，附注释说明约束来源。
- `AiFuncFormatSplitPrompt`：输出要求改为“以 JSON 格式输出修正后的文本，结果放入 formatedText 字段”。

## 验证

- 用 uniapi 真实端点 + `deepseek-v4-flash` curl 验证：旧提示词稳定复现 400/10305，两处新提示词均正常返回符合 schema 的 JSON（translate / formatedText）。
- 修复不涉及逻辑与类型变化，仅提示词字符串；worktree 无依赖故未跑 lint。