### PR TITLE
refactor(storage): 片段存储迁移到文件系统网关并改为异步访问

### DIFF
--- a/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
+++ b/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
@@ -1,15 +1,25 @@
-import { injectable } from 'inversify';
 import path from 'path';
-import fs from 'fs';
 import { OssService } from '@/backend/services/OssService';
 import { getMainLogger } from '@/backend/infrastructure/logger';
 import { OssBaseMeta } from '@/common/types/clipMeta';
+import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
 
-@injectable()
+/**
+ * 片段本地存储的通用实现；仅由具体子类继承，不直接在容器中注册。
+ */
 export default abstract class AbstractOssServiceImpl<T> implements OssService<T> {
     private readonly logger = getMainLogger('AbstractOssServiceImpl');
 
     private readonly METADATA_FILE = 'metadata.json';
+
+    /**
+     * 文件系统访问入口；由具体子类通过构造函数传入。
+     */
+    protected readonly fileSystemGateway: FileSystemGateway;
+
+    protected constructor(fileSystemGateway: FileSystemGateway) {
+        this.fileSystemGateway = fileSystemGateway;
+    }
 
     /**
      * 获取存储库的基本路径
@@ -36,9 +46,8 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
     public async putFile(key: string, fileName: string, sourcePath: string) {
         const clipDir = path.join(await this.getBasePath(), key);
         try {
-            fs.mkdirSync(clipDir, { recursive: true });
-            const destPath = path.join(clipDir, fileName);
-            fs.copyFileSync(sourcePath, destPath);
+            await this.fileSystemGateway.ensureDirectory(clipDir);
+            await this.fileSystemGateway.copyFile(sourcePath, path.join(clipDir, fileName));
         } catch (error) {
             this.logger.error('failed to add file', { fileName, error });
             throw error;
@@ -48,30 +57,53 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
     public async delete(key: string) {
         const clipDir = path.join(await this.getBasePath(), key);
         try {
-            fs.rmSync(clipDir, { recursive: true, force: true });
+            await this.fileSystemGateway.removeDirectoryIfExists(clipDir);
         } catch (error) {
             this.logger.error('failed to delete file', { error });
             throw error;
         }
     }
 
+    /**
+     * 读取片段元数据。
+     *
+     * 行为说明：
+     * - 片段目录不存在时返回 `null`，表示片段确实不存在；
+     * - 目录存在但元数据缺失、损坏或未通过版本校验时直接抛错，
+     *   避免把数据损坏伪装成“片段不存在”被上层静默过滤。
+     *
+     * @param key 片段 key。
+     * @returns 校验通过的元数据；片段不存在时返回 `null`。
+     */
     public async get(key: string): Promise<OssBaseMeta & T | null> {
         const clipDir = path.join(await this.getBasePath(), key);
+        const metadataPath = path.join(clipDir, this.METADATA_FILE);
+
+        if (await this.fileSystemGateway.pathIsMissing(clipDir)) {
+            return null;
+        }
+
         try {
-            const metadataPath = path.join(clipDir, this.METADATA_FILE);
-            if (!fs.existsSync(metadataPath)) {
-                return null;
+            if (await this.fileSystemGateway.pathIsMissing(metadataPath)) {
+                throw new Error(`片段目录缺少元数据文件：${metadataPath}`);
             }
-            const metaFileInfo: T & OssBaseMeta = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-            const res = {
-                ...metaFileInfo,
-                key: key,
-                baseDir: clipDir
-            };
-            return this.parseMetadata(res);
+
+            const metadataText = await this.fileSystemGateway.readTextFile(metadataPath);
+            let rawMetadata: Record<string, unknown>;
+            try {
+                rawMetadata = JSON.parse(metadataText) as Record<string, unknown>;
+            } catch (error) {
+                throw new Error(`片段元数据不是合法 JSON：${metadataPath}`, { cause: error });
+            }
+
+            const parsed = this.parseMetadata({ ...rawMetadata, key: key, baseDir: clipDir });
+            if (parsed === null) {
+                throw new Error(`片段元数据未通过版本校验：${metadataPath}`);
+            }
+            return parsed;
         } catch (error) {
             this.logger.error('failed to retrieve file', { error });
-            return null;
+            throw error;
         }
     }
 
@@ -81,6 +113,7 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
      * 行为说明：
      * - 先写入临时文件，再通过 rename 覆盖正式文件，尽量避免进程中断导致的半写入。
      * - 当原文件不存在时，会基于空对象构建完整元数据。
+     * - 校验失败或写入失败时会清理临时文件，不留在片段目录里。
      *
      * @param key 片段 key。
      * @param newMetadata 需要合并的新元数据。
@@ -90,10 +123,10 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
         const metadataPath = path.join(clipDir, this.METADATA_FILE);
         const tempMetadataPath = `${metadataPath}.tmp`;
         try {
-            fs.mkdirSync(clipDir, { recursive: true });
-            const existingMetadata = fs.existsSync(metadataPath)
-                ? JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
-                : {};
+            await this.fileSystemGateway.ensureDirectory(clipDir);
+            const existingMetadata = await this.fileSystemGateway.pathIsMissing(metadataPath)
+                ? {}
+                : JSON.parse(await this.fileSystemGateway.readTextFile(metadataPath));
             const updatedMetadata = {
                 ...existingMetadata,
                 version: this.getVersion(),
@@ -104,13 +137,11 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
             if (!this.verifyNewMetadata(updatedMetadata)) {
                 throw new Error('Invalid metadata');
             }
-            fs.writeFileSync(tempMetadataPath, JSON.stringify(updatedMetadata, null, 2));
-            fs.renameSync(tempMetadataPath, metadataPath);
+            await this.fileSystemGateway.writeTextFile(tempMetadataPath, JSON.stringify(updatedMetadata, null, 2));
+            await this.fileSystemGateway.moveFile(tempMetadataPath, metadataPath);
         } catch (error) {
             try {
-                if (fs.existsSync(tempMetadataPath)) {
-                    fs.rmSync(tempMetadataPath, { force: true });
-                }
+                await this.fileSystemGateway.removeFileIfExists(tempMetadataPath);
             } catch {
                 // 清理临时文件失败时不阻断主流程
             }
@@ -121,14 +152,11 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
 
     public async list(): Promise<string[]> {
         const basePath = await this.getBasePath();
-        if (!fs.existsSync(basePath)) {
+        if (!(await this.fileSystemGateway.directoryExists(basePath))) {
             return [];
         }
         try {
-            const items = fs.readdirSync(basePath, { withFileTypes: true });
-            return items
-                .filter(item => item.isDirectory())
-                .map(item => item.name);
+            return await this.fileSystemGateway.listDirectoryNames(basePath);
         } catch (error) {
             this.logger.error('failed to list objects', { error });
             throw error;

--- a/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
+++ b/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { injectable } from 'inversify';
 import { OssService } from '@/backend/services/OssService';
 import { getMainLogger } from '@/backend/infrastructure/logger';
 import { OssBaseMeta } from '@/common/types/clipMeta';
@@ -6,7 +7,11 @@ import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGat
 
 /**
  * 片段本地存储的通用实现；仅由具体子类继承，不直接在容器中注册。
+ *
+ * `@injectable` 不能省：inversify 解析子类时会沿原型链检查基类的装饰器元数据，
+ * 缺失会在容器解析时抛「Missing required @injectable annotation」。
  */
+@injectable()
 export default abstract class AbstractOssServiceImpl<T> implements OssService<T> {
     private readonly logger = getMainLogger('AbstractOssServiceImpl');
 
@@ -17,7 +22,10 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
      */
     protected readonly fileSystemGateway: FileSystemGateway;
 
-    protected constructor(fileSystemGateway: FileSystemGateway) {
+    /**
+     * 构造函数必须为 public：inversify 的 `@injectable` 要求构造器是 public 签名。
+     */
+    public constructor(fileSystemGateway: FileSystemGateway) {
         this.fileSystemGateway = fileSystemGateway;
     }
 

--- a/src/backend/infrastructure/storage/ClipOssServiceImpl.ts
+++ b/src/backend/infrastructure/storage/ClipOssServiceImpl.ts
@@ -5,23 +5,30 @@ import TYPES from '@/backend/ioc/types';
 import { ClipOssService } from '@/backend/services/OssService';
 import path from 'path';
 import FfmpegService from '@/backend/services/FfmpegService';
-import fs from 'fs';
 import { MetaDataSchemaV1 } from '@/common/types/clipMeta/ClipMetaDataV1';
 import { OssBaseSchema } from '@/common/types/clipMeta/base';
+import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
 import StorageDirectoryProvider, {
     StorageDirectoryTarget,
 } from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 
 @injectable()
 export default class ClipOssServiceImpl extends AbstractOssServiceImpl<ClipMeta> implements ClipOssService {
-    @inject(TYPES.StorageDirectoryProvider)
-    private storageDirectoryProvider!: StorageDirectoryProvider;
-
-    @inject(TYPES.FfmpegService)
-    private ffmpegService!: FfmpegService;
+    private readonly storageDirectoryProvider: StorageDirectoryProvider;
+    private readonly ffmpegService: FfmpegService;
 
     private readonly CLIP_FILE = 'clip.mp4';
     private readonly THUMBNAIL_FILE = 'thumbnail.jpg';
+
+    constructor(
+        @inject(TYPES.FileSystemGateway) fileSystemGateway: FileSystemGateway,
+        @inject(TYPES.StorageDirectoryProvider) storageDirectoryProvider: StorageDirectoryProvider,
+        @inject(TYPES.FfmpegService) ffmpegService: FfmpegService,
+    ) {
+        super(fileSystemGateway);
+        this.storageDirectoryProvider = storageDirectoryProvider;
+        this.ffmpegService = ffmpegService;
+    }
 
     getVersion(): number {
         return ClipVersion;
@@ -67,25 +74,39 @@ export default class ClipOssServiceImpl extends AbstractOssServiceImpl<ClipMeta>
         return MetaDataSchemaV1.merge(OssBaseSchema).safeParse(metadata).success;
     }
 
+    /**
+     * 写入一条收藏片段：生成缩略图、复制片段文件并落元数据。
+     *
+     * 行为说明：
+     * - 临时缩略图在 finally 中清理，收藏中途失败也不会遗留在 temp 目录。
+     *
+     * @param key 片段 key。
+     * @param sourcePath 待收藏的临时片段文件绝对路径。
+     * @param metadata 片段业务元数据。
+     */
     async putClip(key: string, sourcePath: string, metadata: ClipMeta): Promise<void> {
         const tempFolder = await this.storageDirectoryProvider.provideDirectory(StorageDirectoryTarget.TEMP);
         // 生成缩略图
         const thumbnailFileName = `${key}-${this.THUMBNAIL_FILE}`;
-        const length = await this.ffmpegService.duration(sourcePath);
-        await this.ffmpegService.thumbnail({
-            inputFile: sourcePath,
-            outputFileName: thumbnailFileName,
-            outputFolder: tempFolder,
-            time: length / 2
-        });
-        await this.putFile(key, this.THUMBNAIL_FILE, path.join(tempFolder, thumbnailFileName));
-        await this.putFile(key, this.CLIP_FILE, sourcePath);
-        await this.updateMetadata(key, {
-            ...metadata,
-            clip_file: this.CLIP_FILE,
-            thumbnail_file: this.THUMBNAIL_FILE
-        });
-        fs.rmSync(path.join(tempFolder, thumbnailFileName));
+        const tempThumbnailPath = path.join(tempFolder, thumbnailFileName);
+        try {
+            const length = await this.ffmpegService.duration(sourcePath);
+            await this.ffmpegService.thumbnail({
+                inputFile: sourcePath,
+                outputFileName: thumbnailFileName,
+                outputFolder: tempFolder,
+                time: length / 2
+            });
+            await this.putFile(key, this.THUMBNAIL_FILE, tempThumbnailPath);
+            await this.putFile(key, this.CLIP_FILE, sourcePath);
+            await this.updateMetadata(key, {
+                ...metadata,
+                clip_file: this.CLIP_FILE,
+                thumbnail_file: this.THUMBNAIL_FILE
+            });
+        } finally {
+            await this.fileSystemGateway.removeFileIfExists(tempThumbnailPath);
+        }
     }
 
     async updateTags(key: string, tags: string[]): Promise<void> {

--- a/src/backend/infrastructure/storage/FileSystemGatewayImpl.ts
+++ b/src/backend/infrastructure/storage/FileSystemGatewayImpl.ts
@@ -103,6 +103,15 @@ export default class FileSystemGatewayImpl implements FileSystemGateway {
     }
 
     /**
+     * 复制普通文件。
+     * @param sourcePath 源文件绝对路径。
+     * @param targetPath 目标文件绝对路径。
+     */
+    public async copyFile(sourcePath: string, targetPath: string): Promise<void> {
+        await fs.copyFile(sourcePath, targetPath);
+    }
+
+    /**
      * 写入 UTF-8 文本文件。
      * @param filePath 文件绝对路径。
      * @param content 待写入的文本内容。

--- a/src/backend/infrastructure/storage/VideoLearningOssServiceImpl.ts
+++ b/src/backend/infrastructure/storage/VideoLearningOssServiceImpl.ts
@@ -5,23 +5,30 @@ import TYPES from '@/backend/ioc/types';
 import { ClipOssService } from '@/backend/services/OssService';
 import path from 'path';
 import FfmpegService from '@/backend/services/FfmpegService';
-import fs from 'fs';
 import { MetaDataSchemaV1 } from '@/common/types/clipMeta/ClipMetaDataV1';
 import { OssBaseSchema } from '@/common/types/clipMeta/base';
+import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
 import StorageDirectoryProvider, {
     StorageDirectoryTarget,
 } from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 
 @injectable()
 export default class VideoLearningOssServiceImpl extends AbstractOssServiceImpl<ClipMeta> implements ClipOssService {
-    @inject(TYPES.StorageDirectoryProvider)
-    private storageDirectoryProvider!: StorageDirectoryProvider;
-
-    @inject(TYPES.FfmpegService)
-    private ffmpegService!: FfmpegService;
+    private readonly storageDirectoryProvider: StorageDirectoryProvider;
+    private readonly ffmpegService: FfmpegService;
 
     private readonly CLIP_FILE = 'clip.mp4';
     private readonly THUMBNAIL_FILE = 'thumbnail.jpg';
+
+    constructor(
+        @inject(TYPES.FileSystemGateway) fileSystemGateway: FileSystemGateway,
+        @inject(TYPES.StorageDirectoryProvider) storageDirectoryProvider: StorageDirectoryProvider,
+        @inject(TYPES.FfmpegService) ffmpegService: FfmpegService,
+    ) {
+        super(fileSystemGateway);
+        this.storageDirectoryProvider = storageDirectoryProvider;
+        this.ffmpegService = ffmpegService;
+    }
 
     getVersion(): number {
         return ClipVersion;
@@ -52,25 +59,39 @@ export default class VideoLearningOssServiceImpl extends AbstractOssServiceImpl<
         return MetaDataSchemaV1.merge(OssBaseSchema).safeParse(metadata).success;
     }
 
+    /**
+     * 写入一条单词视频片段：生成缩略图、复制片段文件并落元数据。
+     *
+     * 行为说明：
+     * - 临时缩略图在 finally 中清理，写入中途失败也不会遗留在 temp 目录。
+     *
+     * @param key 片段 key。
+     * @param sourcePath 待写入的临时片段文件绝对路径。
+     * @param metadata 片段业务元数据。
+     */
     async putClip(key: string, sourcePath: string, metadata: ClipMeta): Promise<void> {
         const tempFolder = await this.storageDirectoryProvider.provideDirectory(StorageDirectoryTarget.TEMP);
         // 生成缩略图
         const thumbnailFileName = `${key}-${this.THUMBNAIL_FILE}`;
-        const length = await this.ffmpegService.duration(sourcePath);
-        await this.ffmpegService.thumbnail({
-            inputFile: sourcePath,
-            outputFileName: thumbnailFileName,
-            outputFolder: tempFolder,
-            time: length / 2
-        });
-        await this.putFile(key, this.THUMBNAIL_FILE, path.join(tempFolder, thumbnailFileName));
-        await this.putFile(key, this.CLIP_FILE, sourcePath);
-        await this.updateMetadata(key, {
-            ...metadata,
-            clip_file: this.CLIP_FILE,
-            thumbnail_file: this.THUMBNAIL_FILE
-        });
-        fs.rmSync(path.join(tempFolder, thumbnailFileName));
+        const tempThumbnailPath = path.join(tempFolder, thumbnailFileName);
+        try {
+            const length = await this.ffmpegService.duration(sourcePath);
+            await this.ffmpegService.thumbnail({
+                inputFile: sourcePath,
+                outputFileName: thumbnailFileName,
+                outputFolder: tempFolder,
+                time: length / 2
+            });
+            await this.putFile(key, this.THUMBNAIL_FILE, tempThumbnailPath);
+            await this.putFile(key, this.CLIP_FILE, sourcePath);
+            await this.updateMetadata(key, {
+                ...metadata,
+                clip_file: this.CLIP_FILE,
+                thumbnail_file: this.THUMBNAIL_FILE
+            });
+        } finally {
+            await this.fileSystemGateway.removeFileIfExists(tempThumbnailPath);
+        }
     }
 
     async updateTags(key: string, tags: string[]): Promise<void> {

--- a/src/backend/infrastructure/storage/__tests__/AbstractOssServiceImpl.test.ts
+++ b/src/backend/infrastructure/storage/__tests__/AbstractOssServiceImpl.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
+import AbstractOssServiceImpl from '@/backend/infrastructure/storage/AbstractOssServiceImpl';
+import { OssBaseMeta } from '@/common/types/clipMeta';
+
+// 日志模块是系统边界：测试里静音，避免真实落盘和对 Electron app 的依赖。
+vi.mock('@/backend/infrastructure/logger', () => ({
+    getMainLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+/**
+ * 基于内存 Map 的文件系统网关实现，仅覆盖抽象存储类用到的行为语义。
+ */
+class MemoryFileSystemGateway implements FileSystemGateway {
+    /** 文件路径到文本内容的映射。 */
+    public readonly files = new Map<string, string>();
+    /** 已存在的目录集合。 */
+    public readonly directories = new Set<string>();
+
+    private normalize(targetPath: string): string {
+        return path.normalize(targetPath);
+    }
+
+    private missingPathError(targetPath: string): NodeJS.ErrnoException {
+        const error = new Error(`ENOENT: no such file or directory, ${targetPath}`) as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        return error;
+    }
+
+    public async ensureDirectory(directoryPath: string): Promise<void> {
+        const dirPath = this.normalize(directoryPath);
+        this.directories.add(dirPath);
+        let parentPath = path.dirname(dirPath);
+        while (parentPath && parentPath !== dirPath && !this.directories.has(parentPath)) {
+            this.directories.add(parentPath);
+            parentPath = path.dirname(parentPath);
+        }
+    }
+
+    public async fileExists(filePath: string): Promise<boolean> {
+        return this.files.has(this.normalize(filePath));
+    }
+
+    public async directoryExists(directoryPath: string): Promise<boolean> {
+        return this.directories.has(this.normalize(directoryPath));
+    }
+
+    public async getFileSize(filePath: string): Promise<number> {
+        const content = this.files.get(this.normalize(filePath));
+        if (content === undefined) {
+            throw this.missingPathError(filePath);
+        }
+        return content.length;
+    }
+
+    public async readTextFile(filePath: string): Promise<string> {
+        const content = this.files.get(this.normalize(filePath));
+        if (content === undefined) {
+            throw this.missingPathError(filePath);
+        }
+        return content;
+    }
+
+    public async getDirectorySize(directoryPath: string): Promise<number> {
+        const dirPath = this.normalize(directoryPath);
+        let totalSize = 0;
+        for (const [filePath, content] of this.files) {
+            if (filePath.startsWith(dirPath + path.sep)) {
+                totalSize += content.length;
+            }
+        }
+        return totalSize;
+    }
+
+    public async copyFile(sourcePath: string, targetPath: string): Promise<void> {
+        const content = this.files.get(this.normalize(sourcePath));
+        if (content === undefined) {
+            throw this.missingPathError(sourcePath);
+        }
+        this.files.set(this.normalize(targetPath), content);
+    }
+
+    public async writeTextFile(filePath: string, content: string): Promise<void> {
+        this.files.set(this.normalize(filePath), content);
+    }
+
+    public async moveFile(sourcePath: string, targetPath: string): Promise<void> {
+        const normalizedSource = this.normalize(sourcePath);
+        const content = this.files.get(normalizedSource);
+        if (content === undefined) {
+            throw this.missingPathError(sourcePath);
+        }
+        this.files.delete(normalizedSource);
+        this.files.set(this.normalize(targetPath), content);
+    }
+
+    public async removeFileIfExists(filePath: string): Promise<void> {
+        this.files.delete(this.normalize(filePath));
+    }
+
+    public async removeDirectoryIfExists(directoryPath: string): Promise<void> {
+        const dirPath = this.normalize(directoryPath);
+        this.directories.delete(dirPath);
+        for (const filePath of [...this.files.keys()]) {
+            if (filePath === dirPath || filePath.startsWith(dirPath + path.sep)) {
+                this.files.delete(filePath);
+            }
+        }
+        for (const childPath of [...this.directories]) {
+            if (childPath === dirPath || childPath.startsWith(dirPath + path.sep)) {
+                this.directories.delete(childPath);
+            }
+        }
+    }
+
+    public async listFileNames(directoryPath: string): Promise<string[]> {
+        const dirPath = this.normalize(directoryPath);
+        return [...this.files.keys()]
+            .filter(filePath => path.dirname(filePath) === dirPath)
+            .map(filePath => path.basename(filePath));
+    }
+
+    public async listDirectoryNames(directoryPath: string): Promise<string[]> {
+        const dirPath = this.normalize(directoryPath);
+        return [...this.directories]
+            .filter(childPath => childPath !== dirPath && path.dirname(childPath) === dirPath)
+            .map(childPath => path.basename(childPath));
+    }
+
+    public async removeEmptySubdirectories(directoryPath: string): Promise<void> {
+        const dirPath = this.normalize(directoryPath);
+        const children = [...this.directories].filter(
+            childPath => childPath !== dirPath && path.dirname(childPath) === dirPath
+        );
+        for (const childPath of children) {
+            await this.removeEmptySubdirectories(childPath);
+        }
+        const hasContent = [...this.files.keys()].some(
+            filePath => path.dirname(filePath) === dirPath
+        ) || this.directories.has(dirPath) === false;
+        if (!hasContent && this.directories.has(dirPath)) {
+            this.directories.delete(dirPath);
+        }
+    }
+
+    public async pathIsMissing(targetPath: string): Promise<boolean> {
+        const normalizedPath = this.normalize(targetPath);
+        return !this.files.has(normalizedPath) && !this.directories.has(normalizedPath);
+    }
+}
+
+/** 测试用片段元数据。 */
+interface TestClipMeta {
+    label: string;
+}
+
+/**
+ * 抽象存储类的最小具体实现，用于验证通用 CRUD 行为。
+ */
+class TestOssServiceImpl extends AbstractOssServiceImpl<TestClipMeta> {
+    constructor(fileSystemGateway: FileSystemGateway, private readonly basePath: string) {
+        super(fileSystemGateway);
+    }
+
+    async getBasePath(): Promise<string> {
+        return this.basePath;
+    }
+
+    getVersion(): number {
+        return 1;
+    }
+
+    verifyNewMetadata(metadata: unknown): boolean {
+        if (typeof metadata !== 'object' || metadata === null) {
+            return false;
+        }
+        const record = metadata as Record<string, unknown>;
+        return record.version === 1 && typeof record.label === 'string';
+    }
+
+    parseMetadata(metadata: unknown): OssBaseMeta & TestClipMeta | null {
+        return this.verifyNewMetadata(metadata) ? metadata as OssBaseMeta & TestClipMeta : null;
+    }
+}
+
+describe('片段本地存储抽象类', () => {
+    const basePath = path.join('/', 'storage', 'clips');
+    let gateway: MemoryFileSystemGateway;
+    let storage: TestOssServiceImpl;
+
+    beforeEach(() => {
+        gateway = new MemoryFileSystemGateway();
+        storage = new TestOssServiceImpl(gateway, basePath);
+    });
+
+    describe('写入片段文件', () => {
+        it('把源文件复制进片段目录', async () => {
+            await gateway.writeTextFile(path.join('/', 'tmp', 'source.mp4'), 'video-bytes');
+
+            await storage.putFile('k1', 'clip.mp4', path.join('/', 'tmp', 'source.mp4'));
+
+            const clipDir = path.join(basePath, 'k1');
+            expect(await gateway.directoryExists(clipDir)).toBe(true);
+            expect(await gateway.readTextFile(path.join(clipDir, 'clip.mp4'))).toBe('video-bytes');
+        });
+
+        it('源文件不存在时报错', async () => {
+            await expect(
+                storage.putFile('k1', 'clip.mp4', path.join('/', 'tmp', 'missing.mp4'))
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('删除片段', () => {
+        it('删除整个片段目录', async () => {
+            await gateway.writeTextFile(path.join('/', 'tmp', 'source.mp4'), 'video-bytes');
+            await storage.putFile('k1', 'clip.mp4', path.join('/', 'tmp', 'source.mp4'));
+
+            await storage.delete('k1');
+
+            expect(await gateway.pathIsMissing(path.join(basePath, 'k1'))).toBe(true);
+        });
+
+        it('删除不存在的片段不报错', async () => {
+            await expect(storage.delete('not-exist')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('读取元数据', () => {
+        it('片段不存在时返回空', async () => {
+            expect(await storage.get('not-exist')).toBeNull();
+        });
+
+        it('写入元数据后能读回完整内容', async () => {
+            await storage.updateMetadata('k1', { label: 'hello' });
+
+            const meta = await storage.get('k1');
+            expect(meta).toMatchObject({
+                key: 'k1',
+                baseDir: path.join(basePath, 'k1'),
+                version: 1,
+                label: 'hello',
+            });
+        });
+
+        it('更新元数据时保留原有字段', async () => {
+            await storage.updateMetadata('k1', { label: 'first' });
+            await storage.updateMetadata('k1', {});
+
+            const meta = await storage.get('k1');
+            expect(meta?.label).toBe('first');
+        });
+
+        it('片段目录存在但元数据文件缺失时报错', async () => {
+            await gateway.ensureDirectory(path.join(basePath, 'k1'));
+
+            await expect(storage.get('k1')).rejects.toThrow('缺少元数据文件');
+        });
+
+        it('元数据内容损坏时报错，而不是当作片段不存在', async () => {
+            const clipDir = path.join(basePath, 'k1');
+            await gateway.ensureDirectory(clipDir);
+            await gateway.writeTextFile(path.join(clipDir, 'metadata.json'), '{oops');
+
+            await expect(storage.get('k1')).rejects.toThrow('不是合法 JSON');
+        });
+
+        it('元数据未通过版本校验时报错', async () => {
+            const clipDir = path.join(basePath, 'k1');
+            await gateway.ensureDirectory(clipDir);
+            await gateway.writeTextFile(
+                path.join(clipDir, 'metadata.json'),
+                JSON.stringify({ version: 999, label: 'x' })
+            );
+
+            await expect(storage.get('k1')).rejects.toThrow('未通过版本校验');
+        });
+    });
+
+    describe('更新元数据', () => {
+        it('校验失败时不落盘也不留临时文件', async () => {
+            await expect(
+                storage.updateMetadata('k1', { label: 123 as unknown as string })
+            ).rejects.toThrow('Invalid metadata');
+
+            const clipDir = path.join(basePath, 'k1');
+            expect(await gateway.pathIsMissing(path.join(clipDir, 'metadata.json'))).toBe(true);
+            expect(await gateway.pathIsMissing(path.join(clipDir, 'metadata.json.tmp'))).toBe(true);
+        });
+    });
+
+    describe('列出片段', () => {
+        it('返回根目录下的全部片段目录', async () => {
+            await gateway.writeTextFile(path.join('/', 'tmp', 'source.mp4'), 'video-bytes');
+            await storage.putFile('k1', 'clip.mp4', path.join('/', 'tmp', 'source.mp4'));
+            await storage.putFile('k2', 'clip.mp4', path.join('/', 'tmp', 'source.mp4'));
+
+            expect(await storage.list()).toEqual(['k1', 'k2']);
+        });
+
+        it('根目录不存在时返回空列表', async () => {
+            expect(await storage.list()).toEqual([]);
+        });
+    });
+});

--- a/src/backend/infrastructure/storage/__tests__/oss-service-container.test.ts
+++ b/src/backend/infrastructure/storage/__tests__/oss-service-container.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import TYPES from '@/backend/ioc/types';
+import ClipOssServiceImpl from '@/backend/infrastructure/storage/ClipOssServiceImpl';
+import VideoLearningOssServiceImpl from '@/backend/infrastructure/storage/VideoLearningOssServiceImpl';
+import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
+import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
+import FfmpegService from '@/backend/services/FfmpegService';
+
+// 日志模块是系统边界：测试里静音，避免真实落盘和对 Electron app 的依赖。
+vi.mock('@/backend/infrastructure/logger', () => ({
+    getMainLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+/**
+ * 验证片段存储实现能被 inversify 容器按生产装配方式解析。
+ *
+ * 这层测试防的是「直接 new 能跑、容器解析炸了」的装配问题：
+ * inversify 解析子类时会沿原型链检查基类的 @injectable 元数据，
+ * 基类装饰器缺失只有在容器解析路径上才会暴露。
+ */
+describe('片段存储实现的 IoC 装配', () => {
+    /** 构造一个绑定了片段存储全部构造依赖的隔离容器。 */
+    function buildContainer(): Container {
+        const container = new Container();
+        container.bind<FileSystemGateway>(TYPES.FileSystemGateway)
+            .toConstantValue({} as FileSystemGateway);
+        container.bind<StorageDirectoryProvider>(TYPES.StorageDirectoryProvider)
+            .toConstantValue({} as StorageDirectoryProvider);
+        container.bind<FfmpegService>(TYPES.FfmpegService)
+            .toConstantValue({} as FfmpegService);
+        return container;
+    }
+
+    it('收藏片段存储实现可以从容器解析并具备业务方法', () => {
+        const container = buildContainer();
+        container.bind(ClipOssServiceImpl).toSelf();
+
+        const storage = container.get(ClipOssServiceImpl);
+
+        expect(typeof storage.putClip).toBe('function');
+        expect(typeof storage.get).toBe('function');
+        expect(typeof storage.list).toBe('function');
+    });
+
+    it('单词视频存储实现可以从容器解析并具备业务方法', () => {
+        const container = buildContainer();
+        container.bind(VideoLearningOssServiceImpl).toSelf();
+
+        const storage = container.get(VideoLearningOssServiceImpl);
+
+        expect(typeof storage.putClip).toBe('function');
+        expect(typeof storage.get).toBe('function');
+        expect(typeof storage.list).toBe('function');
+    });
+});

--- a/src/backend/services/gateways/storage/FileSystemGateway.ts
+++ b/src/backend/services/gateways/storage/FileSystemGateway.ts
@@ -51,6 +51,13 @@ export default interface FileSystemGateway {
     getDirectorySize(directoryPath: string): Promise<number>;
 
     /**
+     * 复制普通文件。
+     * @param sourcePath 源文件绝对路径。
+     * @param targetPath 目标文件绝对路径；目标路径的目录需已存在。
+     */
+    copyFile(sourcePath: string, targetPath: string): Promise<void>;
+
+    /**
      * 写入 UTF-8 文本文件。
      * @param filePath 文件绝对路径。
      * @param content 待写入的文本内容。


### PR DESCRIPTION
## 背景

收藏片段的本地存储层（`AbstractOssServiceImpl` 及两个子类）此前绕过了 `FileSystemGateway`，直接使用同步 fs API（`copyFileSync` / `rmSync` / `readFileSync` 等）。虽然方法签名是 `async`，实际全部在主进程事件循环上同步执行：收藏片段复制 clip.mp4、删除目录、列表扫描时整个应用卡死（IPC、播放器同步、日志全部停摆），且此前该层没有任何测试。

## 改动

- `FileSystemGateway` 接口与实现补齐 `copyFile` 能力
- `AbstractOssServiceImpl` 全部方法迁移到网关异步调用
- `get()` 拆分错误语义：目录不存在返回 `null`；目录存在但元数据缺失 / 非 JSON / 版本不匹配时显式抛错（原来统统吞成 `null`，数据损坏被伪装成“片段不存在”，`syncFromOss` 恢复路径也会静默跳过坏片段）
- 两个子类改为构造函数注入依赖（符合测试规约第 3 节）；`putClip` 临时缩略图改 `finally` 清理，中途失败不再遗留 temp 文件
- 新增内存文件系统下的抽象类行为测试（13 个用例）

## 验证步骤

- [x] `AbstractOssServiceImpl.test.ts` 13/13 通过
- [x] 全量 `yarn test:run` 与基线一致（唯一失败的 `TagService` 为 better-sqlite3 ABI 存量环境问题，干净 main 上同样失败）
- [x] `npx tsc --noEmit` 无新增错误（`preload.ts` 的 `SimpleEvent` 为存量错误）
- [x] `yarn lint` 无新增问题
- [x] 真机验证：收藏片段 / 删除收藏 / 收藏列表 / 单词视频流程

> 注意：行为变化点——元数据损坏时 `get()` 现在会抛错而非静默过滤。上层 `search()` / `syncFromOss()` 的逐条容错与汇总上报将在后续 PR 处理。