### PR TITLE
fix(update-check): ETag 条件请求省限额，开发环境跳过检查，失败原因错误码化

### DIFF
--- a/src/backend/services/CheckUpdate.ts
+++ b/src/backend/services/CheckUpdate.ts
@@ -4,6 +4,7 @@ import { compareVersions } from 'compare-versions';
 import Release from '@/common/types/release';
 import { UpdateCheckResult } from '@/common/types/update-check';
 import { app } from 'electron';
+import { isDevelopmentMode } from '@/backend/utils/runtimeEnv';
 
 const UPDATE_CACHE_TTL_MS = 5 * 60 * 1000;
 /** 限流失败缓存时长：GitHub 匿名限流窗口较长，失败后延长缓存避免在窗口内反复触发。 */
@@ -15,6 +16,15 @@ let cache: UpdateCheckResult = { status: 'ok', releases: [] };
 let cacheExpireAt = 0;
 /** 进行中的更新检查请求：并发调用共享同一请求，避免缓存过期瞬间多个调用同时打 GitHub。 */
 let inflightRequest: Promise<UpdateCheckResult> | null = null;
+
+/**
+ * 最近一次完整成功检查的快照。
+ *
+ * etag 与结果绑定：携带 If-None-Match 请求 /latest 时，若 GitHub 返回 304，
+ * 说明线上数据与快照时完全一致，可直接复用快照结果。304 响应不计入速率限额，
+ * 是匿名限额（60 次/小时/IP）下最有效的省额手段。
+ */
+let lastSuccess: { etag: string | null; result: UpdateCheckResult } | null = null;
 
 const normalizeVersion = (version: string) => version.trim().replace(/^v/i, '');
 
@@ -53,7 +63,7 @@ const isStableRelease = (release: { draft?: boolean; prerelease?: boolean }) => 
  * - 网络请求失败（含限流）会写入失败缓存：限流失败（403/429）缓存 10 分钟，其余失败缓存 5 分钟；
  * - 解析等意外异常会直接抛出、不写缓存，避免用错误数据掩盖问题。
  *
- * @returns 更新检查结果（含版本列表或错误信息）。
+ * @returns 更新检查结果（含版本列表或错误码）。
  */
 export const checkUpdate = (): Promise<UpdateCheckResult> => {
     if (Date.now() < cacheExpireAt) {
@@ -71,8 +81,11 @@ export const checkUpdate = (): Promise<UpdateCheckResult> => {
  * 执行实际的更新检查请求并写入缓存；由 checkUpdate 保证同一时间只有一个实例在跑。
  *
  * 行为说明：
+ * - 开发模式下直接返回“无更新”，避免 package.json 版本落后于线上时误报；
+ * - /latest 携带最近成功快照的 etag，命中 304 时复用快照结果，不消耗速率限额；
  * - /latest 请求失败（含 403 限流）直接返回失败缓存，不再请求列表接口；
- * - 列表接口失败时回退为仅返回 /latest 的单个版本；
+ * - 列表接口失败时回退为仅返回 /latest 的单个版本（该降级结果不写入快照，
+ *   保证 304 复用的永远是完整成功的结果）；
  * - 所有正常与预期失败分支都会设置 cacheExpireAt，失败态同样缓存避免反复请求。
  *
  * @returns 更新检查结果。
@@ -81,26 +94,46 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
     const currentVersion = app.getVersion();
     const logger = getMainLogger('CheckUpdate');
 
+    // 开发模式下 app.getVersion() 取自 package.json，可能落后于线上 Release，跳过避免误报。
+    if (isDevelopmentMode()) {
+        logger.debug('skip update check in development mode');
+        cache = { status: 'ok', releases: [] };
+        cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
+        return cache;
+    }
+
     const latestRequestStart = Date.now();
+    // 仅在持有成功快照时才发送条件请求：没有快照时 304 无结果可复用。
+    const headers = lastSuccess?.etag ? { 'If-None-Match': lastSuccess.etag } : undefined;
     // catch 分支必然 return，能走到后续代码时 latestResponse 一定已成功赋值。
     let latestResponse!: AxiosResponse;
     try {
-        latestResponse = await axios.get(`${RELEASES_BASE_URL}/latest`);
+        latestResponse = await axios.get(`${RELEASES_BASE_URL}/latest`, { headers });
     } catch (err: unknown) {
-        const costMs = Date.now() - latestRequestStart;
         const status = isAxiosError(err) ? err.response?.status : undefined;
+
+        // axios 默认把 3xx 当错误抛出；304 说明数据与快照一致，直接复用快照结果。
+        if (status === 304 && lastSuccess) {
+            logger.debug('latest release unchanged (304), reuse snapshot', {
+                costMs: Date.now() - latestRequestStart,
+            });
+            cache = lastSuccess.result;
+            cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
+            return cache;
+        }
+
         const rateLimited = status === 403 || status === 429;
         // 限流/网络失败均为可恢复的预期失败，按 warn 记录并带上 status/耗时便于归因。
         logger.warn(rateLimited ? 'github latest release rate limited' : 'failed to fetch latest release', {
             status,
             url: `${RELEASES_BASE_URL}/latest`,
-            costMs,
+            costMs: Date.now() - latestRequestStart,
             error: err instanceof Error ? err.message : String(err),
         });
         cache = {
             status: 'error',
             releases: [],
-            error: rateLimited ? 'github api rate limited' : 'failed to fetch latest release',
+            error: rateLimited ? 'rate_limited' : 'network',
         };
         // 限流类失败延长缓存，避免在限流窗口内反复请求；失败态直接返回，避免被后续分支覆盖。
         cacheExpireAt = Date.now() + (rateLimited ? RATE_LIMIT_FAILURE_CACHE_MS : UPDATE_CACHE_TTL_MS);
@@ -109,7 +142,7 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
 
     // axios 默认仅放行 2xx；其余 2xx（如 204）按失败处理，避免解析空 body 抛错。
     if (latestResponse.status !== 200) {
-        cache = { status: 'error', releases: [], error: `unexpected status ${latestResponse.status}` };
+        cache = { status: 'error', releases: [], error: 'payload' };
         cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
         return cache;
     }
@@ -125,12 +158,15 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
     // 显式校验关键字段，避免异常载荷被静默当作“无更新”缓存。
     if (!latestRelease || typeof latestRelease.tag_name !== 'string' || latestRelease.tag_name.length === 0) {
         logger.error('unexpected latest release payload', { status: latestResponse.status, url: `${RELEASES_BASE_URL}/latest` });
-        cache = { status: 'error', releases: [], error: 'unexpected release payload' };
+        cache = { status: 'error', releases: [], error: 'payload' };
         cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
         return cache;
     }
 
-    if (!isStableRelease(latestRelease) || !isNewerVersion(latestRelease.tag_name, currentVersion)) {
+    const latestEtag = typeof latestResponse.headers?.etag === 'string' ? latestResponse.headers.etag : null;
+
+    // /latest 本身只返回非 draft 非 prerelease 的稳定版，无需再做稳定版判断。
+    if (!isNewerVersion(latestRelease.tag_name, currentVersion)) {
         logger.debug('no new release available', {
             currentVersion,
             latestVersion: latestRelease.tag_name,
@@ -138,6 +174,7 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
         });
         cache = { status: 'ok', releases: [] };
         cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
+        lastSuccess = { etag: latestEtag, result: cache };
         return cache;
     }
 
@@ -158,6 +195,7 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
         const fallback = toRelease(latestRelease);
         cache = { status: 'ok', releases: [fallback] };
         cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
+        // 降级结果不写入快照：304 复用必须是完整成功的结果，避免降级态被长期固化。
         return cache;
     }
 
@@ -170,6 +208,7 @@ const doCheckUpdate = async (): Promise<UpdateCheckResult> => {
     logger.info('fetched releases from github', { count: releases.length, costMs: Date.now() - latestRequestStart });
     cache = { status: 'ok', releases };
     cacheExpireAt = Date.now() + UPDATE_CACHE_TTL_MS;
+    lastSuccess = { etag: latestEtag, result: cache };
     return cache;
 };
 

--- a/src/common/types/update-check.ts
+++ b/src/common/types/update-check.ts
@@ -1,8 +1,14 @@
 import Release from '@/common/types/release';
 
+/**
+ * 更新检查失败的错误码。
+ * 前端按码映射 i18n 文案，禁止直接把原始错误信息透给用户。
+ */
+export type UpdateCheckErrorCode = 'rate_limited' | 'network' | 'payload';
+
 export interface UpdateCheckResult {
     status: 'ok' | 'error';
     releases: Release[];
-    error?: string;
+    error?: UpdateCheckErrorCode;
     shouldNotify?: boolean;
 }

--- a/src/fronted/features/settings/CheckUpdate.tsx
+++ b/src/fronted/features/settings/CheckUpdate.tsx
@@ -7,11 +7,10 @@ import { codeBlock } from 'common-tags';
 import useSWR from 'swr';
 import { Skeleton } from '@/fronted/components/ui/skeleton';
 import NewTips from '@/fronted/features/settings/components/NewTips';
-import { cn } from '@/fronted/lib/utils';
 import { settingsApi } from '@/fronted/features/settings/settingsApi';
 import { UpdateCheckResult } from '@/common/types/update-check';
 import { useTranslation as useI18nTranslation } from 'react-i18next';
-import { Compass, ExternalLink, Sparkles } from 'lucide-react';
+import { Compass, ExternalLink } from 'lucide-react';
 
 const CheckUpdate = () => {
     const { t } = useI18nTranslation('settings');
@@ -22,6 +21,10 @@ const CheckUpdate = () => {
 
     const hasNewRelease = (updateResult?.releases?.length ?? 0) > 0;
     const hasError = updateResult?.status === 'error';
+    // 按错误码映射 i18n 文案；未知码兜底到通用失败描述，不透出后端原始信息。
+    const errorText = updateResult?.error
+        ? t(`checkUpdate.errors.${updateResult.error}`, { defaultValue: t('checkUpdate.failedDescription') })
+        : t('checkUpdate.failedDescription');
 
     return (
         <SettingsPageShell
@@ -61,9 +64,7 @@ const CheckUpdate = () => {
                             {hasError ? (
                                 <div className="w-full flex flex-col gap-2 text-destructive">
                                     <h3 className="font-semibold text-sm">{t('checkUpdate.failedTitle')}</h3>
-                                    <p className="text-xs text-muted-foreground">
-                                        {updateResult?.error ?? t('checkUpdate.failedDescription')}
-                                    </p>
+                                    <p className="text-xs text-muted-foreground">{errorText}</p>
                                 </div>
                             ) : hasNewRelease ? (
                                 <div className="space-y-4">

--- a/src/fronted/i18n/locales/en-US/settings.json
+++ b/src/fronted/i18n/locales/en-US/settings.json
@@ -81,6 +81,11 @@
         "openReleases": "Open Release Page",
         "failedTitle": "Failed to check for updates",
         "failedDescription": "Unable to fetch release details right now. Please try again later.",
+        "errors": {
+            "rate_limited": "GitHub request limit reached. Please try again in a few minutes.",
+            "network": "Can't reach GitHub right now. Check your connection and try again.",
+            "payload": "GitHub returned an unreadable response. Please try again later."
+        },
         "latestTitle": "You're up to date! Here's a tip:",
         "tips": {
             "transcriptionBackground": "While transcription is in progress, you can navigate away and continue watching videos. Subtitles update automatically when finished.",

--- a/src/fronted/i18n/locales/zh-CN/settings.json
+++ b/src/fronted/i18n/locales/zh-CN/settings.json
@@ -81,6 +81,11 @@
         "openReleases": "前往发布页",
         "failedTitle": "检查更新失败",
         "failedDescription": "暂时无法获取更新信息，请稍后重试。",
+        "errors": {
+            "rate_limited": "GitHub 请求频率受限，请几分钟后再试。",
+            "network": "暂时无法连接 GitHub，请检查网络后重试。",
+            "payload": "GitHub 返回了无法解析的数据，请稍后重试。"
+        },
         "latestTitle": "当前已是最新版本",
         "tips": {
             "transcriptionBackground": "转录时，你可以离开当前页面继续观看视频，转录会在后台进行并在完成后自动更新字幕。",


### PR DESCRIPTION
## 背景

检查更新机制的一组小修（对应此前 review 的建议 4、5），集中在 `CheckUpdate.ts` 及其展示链路：

1. **ETag 条件请求省限额**：`/releases/latest` 携带最近成功快照的 `If-None-Match`，命中 304 时直接复用快照结果。304 响应不计入 GitHub 匿名速率限额（60 次/小时/IP），可显著降低限流概率——这正是现有代码里 10 分钟限流失败缓存想缓解的场景。快照只在完整成功（含列表接口）后写入，列表失败的降级结果不写入，避免 304 把降级态固化。
2. **开发环境跳过检查**：dev 模式下 `app.getVersion()` 取自 package.json，可能落后于线上 Release 导致误报更新弹 toast，现在直接跳过。
3. **移除恒真的判断**：`/releases/latest` 只返回非 draft 非 prerelease，结果上的 `isStableRelease` 判断恒为真，删除。
4. **失败原因错误码化**：`UpdateCheckResult.error` 从原始英文字符串改为 `rate_limited | network | payload` 错误码，前端按码映射 i18n 文案（中英已补），不再直接透出 `github api rate limited` 这类内部信息。
5. 顺手清理了 `CheckUpdate.tsx` 里两个未使用的导入（`cn`、`Sparkles`）。

## 验证步骤

- `tsc --noEmit`：除 main 上既有的 `preload.ts` 错误外无新增错误
- ESLint（改动文件）：0 error 0 warning
- `vitest run`：163 通过；`TagService.test.ts` 的 10 个失败为本地环境问题（原生模块需经 electron 运行），在未含本改动的 main 检出上同样复现，与本 PR 无关
- 不涉及 `drizzle/` 迁移，无需重新执行 `yarn run download`

## UI 变化

仅设置页「检查更新失败」时的错误文案由原始错误串变为本地化文案（无截图，逻辑为纯文案映射）；启动 toast 行为不变。