### PR TITLE
feat(storage): 片段批量读取容错、冗余权限确认清理与文件访问约定

### DIFF
--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -227,6 +227,33 @@ Infrastructure 的具体实现。
 简单的纯函数继续放在普通工具文件中。不要为了“分层完整”而创建
 `kernel`、`manager` 等目录。
 
+### 2.5 文件访问
+
+后端的文件读写统一通过 `FileSystemGateway`（`services/gateways/storage/`）
+完成，不在业务代码（Service / Controller）中直接 `import fs`：
+
+- 容器绑定的 `TYPES.FileSystemGateway` 是带权限自动恢复的装饰器，
+  外部路径（如 macOS 收回授权的目录）会在操作前自动引导用户恢复，
+  业务代码不需要也不应该再手动调用
+  `ensurePathAccessPermissionIfExists`；
+- 需要新的文件操作时先看网关接口有没有对应方法，没有就加到网关，
+  不要另开裸 fs 调用；
+- 目录解析统一走 `StorageDirectoryProvider`，不要自己拼 `app.getPath` /
+  `path.join` 硬编码目录。
+
+例外（允许直接使用 fs）：
+
+- `FileSystemGatewayImpl` 本身；
+- 外部进程网关（`FfmpegGatewayImpl`、sherpa-onnx）：输入输出路径由
+  对应 Service 层收口点（如 `FfmpegService`）在进程启动前统一确认；
+- 基础设施自举：日志、`ConfigTender`、数据库初始化——它们在 DI 容器
+  可用之前就要读写文件；
+- 内置资源读取（如默认词表）与流式下载/解压（`ModelArchiveInstaller`）。
+
+判断方法很简单：新写或修改的代码如果需要碰磁盘，先问一句
+“这个操作能不能通过 `FileSystemGateway` 表达”；能就走网关，
+不能就先确认自己属于上面哪条例外。
+
 ## 3. Service 之间如何调用
 
 Service 之间可以调用，但必须保持单向关系：

--- a/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
+++ b/src/backend/infrastructure/storage/AbstractOssServiceImpl.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { injectable } from 'inversify';
-import { OssService } from '@/backend/services/OssService';
+import { OssCollection, OssService } from '@/backend/services/OssService';
 import { getMainLogger } from '@/backend/infrastructure/logger';
 import { OssBaseMeta } from '@/common/types/clipMeta';
 import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
@@ -113,6 +113,34 @@ export default abstract class AbstractOssServiceImpl<T> implements OssService<T>
             this.logger.error('failed to retrieve file', { error });
             throw error;
         }
+    }
+
+    /**
+     * 批量读取片段元数据，逐条隔离读取失败。
+     *
+     * 行为说明：
+     * - 片段不存在的 key 静默跳过，与 `get` 返回 `null` 语义一致；
+     * - 元数据损坏等读取失败只影响当条，记错误日志并计入 `failedKeys`，
+     *   不抛出，避免单条坏数据拖垮整个列表或同步流程。
+     *
+     * @param keys 片段 key 列表。
+     * @returns 读取成功的元数据与失败的 key。
+     */
+    public async getAll(keys: string[]): Promise<OssCollection<T>> {
+        const clips: (OssBaseMeta & T)[] = [];
+        const failedKeys: string[] = [];
+        for (const key of keys) {
+            try {
+                const clip = await this.get(key);
+                if (clip !== null) {
+                    clips.push(clip);
+                }
+            } catch (error) {
+                this.logger.error('片段元数据读取失败，已跳过', { key, error });
+                failedKeys.push(key);
+            }
+        }
+        return { clips, failedKeys };
     }
 
     /**

--- a/src/backend/infrastructure/storage/__tests__/AbstractOssServiceImpl.test.ts
+++ b/src/backend/infrastructure/storage/__tests__/AbstractOssServiceImpl.test.ts
@@ -143,6 +143,31 @@ describe('片段本地存储抽象类', () => {
         });
     });
 
+    describe('批量读取元数据', () => {
+        it('逐条返回健康的片段，不存在的 key 静默跳过', async () => {
+            await storage.updateMetadata('k1', { label: 'a' });
+            await storage.updateMetadata('k2', { label: 'b' });
+
+            const { clips, failedKeys } = await storage.getAll(['k1', 'not-exist', 'k2']);
+
+            expect(clips.map((clip) => clip.label)).toEqual(['a', 'b']);
+            expect(failedKeys).toEqual([]);
+        });
+
+        it('单条元数据损坏只影响当条，不会拖垮整批', async () => {
+            await storage.updateMetadata('k1', { label: 'a' });
+            const corruptDir = path.join(basePath, 'k2');
+            await gateway.ensureDirectory(corruptDir);
+            await gateway.writeTextFile(path.join(corruptDir, 'metadata.json'), '{oops');
+            await storage.updateMetadata('k3', { label: 'c' });
+
+            const { clips, failedKeys } = await storage.getAll(['k1', 'k2', 'k3']);
+
+            expect(clips.map((clip) => clip.label)).toEqual(['a', 'c']);
+            expect(failedKeys).toEqual(['k2']);
+        });
+    });
+
     describe('更新元数据', () => {
         it('校验失败时不落盘也不留临时文件', async () => {
             await expect(

--- a/src/backend/services/AiFuncService.ts
+++ b/src/backend/services/AiFuncService.ts
@@ -7,7 +7,6 @@ import UrlUtil from '@/common/utils/UrlUtil';
 import { inject, injectable } from 'inversify';
 import ChatService from '@/backend/services/ChatService';
 import { AiFuncFormatSplitPrompt } from '@/common/types/aiRes/AiFuncFormatSplit';
-import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import ParakeetModelService from '@/backend/services/ParakeetModelService';
 import {
     TranscriptTask,
@@ -51,8 +50,6 @@ export class AiFuncServiceImpl implements AiFuncService {
     @inject(TYPES.ChatService)
     private chatService!: ChatService;
 
-    @inject(TYPES.StorageDirectoryProvider)
-    private storageDirectoryProvider!: StorageDirectoryProvider;
 
     @inject(TYPES.ParakeetModelService)
     private parakeetModelService!: ParakeetModelService;
@@ -113,7 +110,6 @@ export class AiFuncServiceImpl implements AiFuncService {
     public async transcript(params: { filePath: string; currentPosition?: number }): Promise<'started' | 'model_missing'> {
         const { filePath, currentPosition } = params;
         this.logger.info('Transcription task started', { filePath });
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(filePath);
         await this.localTranscriptionService.enqueue(filePath);
 
         const modelStatus = await this.parakeetModelService.getStatus();

--- a/src/backend/services/ConvertService.ts
+++ b/src/backend/services/ConvertService.ts
@@ -3,7 +3,6 @@ import { inject, injectable } from 'inversify';
 import { FolderVideos } from '@/common/contracts/convert';
 import { CancelByUserError } from '@/backend/utils/errors/errors';
 import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
-import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import DpTaskService from '@/backend/services/DpTaskService';
 import FfmpegService from '@/backend/services/FfmpegService';
 import TYPES from '@/backend/ioc/types';
@@ -57,13 +56,11 @@ export class ConvertServiceImpl implements ConvertService {
      * 创建转换用例服务。
      * @param dpTaskService 后台任务状态服务。
      * @param ffmpegService FFmpeg 基础能力服务。
-     * @param storageDirectoryProvider 外部路径权限恢复服务。
      * @param fileSystemGateway 文件系统访问入口。
      */
     constructor(
         @inject(TYPES.DpTaskService) private readonly dpTaskService: DpTaskService,
         @inject(TYPES.FfmpegService) private readonly ffmpegService: FfmpegService,
-        @inject(TYPES.StorageDirectoryProvider) private readonly storageDirectoryProvider: StorageDirectoryProvider,
         @inject(TYPES.FileSystemGateway) private readonly fileSystemGateway: FileSystemGateway,
     ) {}
 
@@ -75,7 +72,6 @@ export class ConvertServiceImpl implements ConvertService {
      * @throws 输入文件不存在或无法访问时直接抛错，不创建任务。
      */
     public async startToMp4(inputFile: string): Promise<number> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(inputFile);
         if (!await this.fileSystemGateway.fileExists(inputFile)) {
             throw new Error(`待转换视频不存在：${inputFile}`);
         }
@@ -96,7 +92,6 @@ export class ConvertServiceImpl implements ConvertService {
     public async listUnconvertedVideos(folders: string[]): Promise<FolderVideos[]> {
         const result: FolderVideos[] = [];
         for (const folder of folders) {
-            await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(folder);
             const fileNames = await this.fileSystemGateway.listFileNames(folder);
             const videos: string[] = [];
 
@@ -123,7 +118,6 @@ export class ConvertServiceImpl implements ConvertService {
      * @returns 已存在的 HTML5 MP4 路径；不存在时返回 `null`。
      */
     public async suggestHtml5Video(filePath: string): Promise<string | null> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(filePath);
         const html5VideoPath = this.isHtml5Video(filePath)
             ? filePath
             : this.buildOutputPaths(filePath).videoPath;

--- a/src/backend/services/FavouriteClipsService.ts
+++ b/src/backend/services/FavouriteClipsService.ts
@@ -388,10 +388,30 @@ export class FavouriteClipsServiceImpl implements FavouriteClipsService {
 
     public async search(query?: ClipQuery): Promise<(OssBaseMeta & ClipMeta)[]> {
         const keys = await this.favouriteClipsRepository.searchClipKeys(query);
-        return Promise.all(keys
-            .map((key) => this.clipOssService.get(key)))
-            .then((res) => res.filter((item) => item !== null)) as Promise<(OssBaseMeta & ClipMeta)[]>;
+        const { clips, failedKeys } = await this.clipOssService.getAll(keys);
+        this.notifyCorruptClips(failedKeys);
+        return clips;
+    }
 
+    /**
+     * 向用户汇总提示无法读取的收藏片段数量。
+     *
+     * 行为说明：
+     * - 单条损坏不阻断列表展示，健康的片段照常返回；
+     * - 提示去重，避免每次刷新列表都重复弹窗。
+     *
+     * @param failedKeys 元数据损坏、无法读取的片段 key。
+     */
+    private notifyCorruptClips(failedKeys: string[]): void {
+        if (failedKeys.length === 0) {
+            return;
+        }
+        this.rendererGateway.fireAndForget('ui/show-toast', {
+            message: `有 ${failedKeys.length} 条收藏片段无法读取，已跳过；详情见日志`,
+            variant: 'warning',
+            duration: 5000,
+            dedupeKey: 'favourite-clip-corrupt',
+        });
     }
 
     private async addToDb(metaData: ClipMeta & OssBaseMeta) {
@@ -457,12 +477,10 @@ export class FavouriteClipsServiceImpl implements FavouriteClipsService {
     async syncFromOss() {
         await concurrency.withMutex('favourite-clip-sync', async () => {
             const keys = await this.clipOssService.list();
+            const { clips: metas, failedKeys } = await this.clipOssService.getAll(keys);
+            this.notifyCorruptClips(failedKeys);
             const clips: FavouriteClipsReplaceAllItem[] = [];
-            for (const key of keys) {
-                const clip = await this.clipOssService.get(key);
-                if (!clip) {
-                    continue;
-                }
+            for (const clip of metas) {
                 const srtLines = clip.clip_content ?? [];
                 const srtContext = srtLines.filter(e => !e.isClip).map(e => e.contentEn).join('\n');
                 const srtClip = srtLines.filter(e => e.isClip).map(e => e.contentEn).join('\n');

--- a/src/backend/services/MediaService.ts
+++ b/src/backend/services/MediaService.ts
@@ -143,7 +143,6 @@ export class MediaServiceImpl implements MediaService {
      * @param sourceFilePath 媒体文件绝对路径。
      */
     private async assertSourceFileExists(sourceFilePath: string): Promise<void> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(sourceFilePath);
         if (!(await this.fileSystemGateway.fileExists(sourceFilePath))) {
             throw new Error(`媒体文件不存在：${sourceFilePath}`);
         }

--- a/src/backend/services/OssService.ts
+++ b/src/backend/services/OssService.ts
@@ -1,5 +1,14 @@
 import { ClipMeta, OssBaseMeta } from '@/common/types/clipMeta';
 
+/**
+ * 批量读取片段元数据的结果。
+ */
+export interface OssCollection<T> {
+    /** 读取成功的片段元数据。 */
+    clips: (OssBaseMeta & T)[];
+    /** 元数据损坏、无法读取的片段 key。 */
+    failedKeys: string[];
+}
 
 export interface ClipOssService extends OssService<ClipMeta> {
 
@@ -14,6 +23,19 @@ export interface OssService<T> {
     delete(key: string): Promise<void>;
 
     get(key: string): Promise<T & OssBaseMeta | null>
+
+    /**
+     * 批量读取片段元数据，逐条隔离读取失败。
+     *
+     * 行为说明：
+     * - 片段不存在的 key 静默跳过，与 `get` 返回 `null` 语义一致；
+     * - 元数据损坏等读取失败只影响当条，不会拖垮整批；
+     * - 调用方可根据 `failedKeys` 向用户汇总提示。
+     *
+     * @param keys 片段 key 列表。
+     * @returns 读取成功的元数据与失败的 key。
+     */
+    getAll(keys: string[]): Promise<OssCollection<T>>;
 
     updateMetadata(key: string, newMetadata: Partial<T>): Promise<void>;
 

--- a/src/backend/services/SplitVideoService.ts
+++ b/src/backend/services/SplitVideoService.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { inject, injectable } from 'inversify';
 import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
-import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import FfmpegService from '@/backend/services/FfmpegService';
 import { VideoSegment } from '@/backend/services/gateways/media/FfmpegGateway';
 import TYPES from '@/backend/ioc/types';
@@ -48,8 +47,6 @@ export class SplitVideoServiceImpl implements SplitVideoService {
     public constructor(
         @inject(TYPES.FfmpegService)
         private readonly ffmpegService: FfmpegService,
-        @inject(TYPES.StorageDirectoryProvider)
-        private readonly storageDirectoryProvider: StorageDirectoryProvider,
         @inject(TYPES.FileSystemGateway)
         private readonly fileSystemGateway: FileSystemGateway,
     ) {}
@@ -92,7 +89,6 @@ export class SplitVideoServiceImpl implements SplitVideoService {
      * @param request 待校验的切分请求。
      */
     private async validateRequest(request: SplitVideoRequest): Promise<void> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(request.videoPath);
         if (!(await this.fileSystemGateway.fileExists(request.videoPath))) {
             throw new Error(`视频文件不存在：${request.videoPath}`);
         }
@@ -131,7 +127,6 @@ export class SplitVideoServiceImpl implements SplitVideoService {
         if (StrUtil.isBlank(request.srtPath)) {
             throw new Error('字幕路径不能为空字符串；不切分字幕时请传入 null');
         }
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(request.srtPath);
         if (!(await this.fileSystemGateway.fileExists(request.srtPath))) {
             throw new Error(`字幕文件不存在：${request.srtPath}`);
         }
@@ -149,7 +144,6 @@ export class SplitVideoServiceImpl implements SplitVideoService {
         chapters: ChapterParseResult[],
         folderName: string,
     ): Promise<VideoSegment[]> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(folderName);
         await this.fileSystemGateway.ensureDirectory(folderName);
 
         const chapterStarts = chapters.map((chapter) => timeTextToSeconds(chapter.timestampStart));

--- a/src/backend/services/SubtitleService.ts
+++ b/src/backend/services/SubtitleService.ts
@@ -10,7 +10,6 @@ import { SubtitleTimestampAdjustment } from '@/common/contracts/subtitle-timesta
 import { ObjUtil } from '@/backend/utils/ObjUtil';
 import { parseSrt, parseAss, srtLineToSentence, SrtLine } from '@/common/utils/subtitle';
 import MediaUtil from '@/common/utils/MediaUtil';
-import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
 import { SubtitleVocabularyAnalysisService } from '@/backend/services/SubtitleVocabularyAnalysisService';
 import {
@@ -155,8 +154,6 @@ export class SubtitleServiceImpl implements SubtitleService {
     private cacheService!: CacheService;
     @inject(TYPES.SubtitleVocabularyAnalysisService)
     private vocabularyAnalysisService!: SubtitleVocabularyAnalysisService;
-    @inject(TYPES.StorageDirectoryProvider)
-    private storageDirectoryProvider!: StorageDirectoryProvider;
     @inject(TYPES.FileSystemGateway)
     private fileSystemGateway!: FileSystemGateway;
 
@@ -172,7 +169,6 @@ export class SubtitleServiceImpl implements SubtitleService {
         if (!(await this.fileSystemGateway.fileExists(path))) {
             throw new Error(`字幕文件不存在：${path}`);
         }
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(path);
         const content = await this.fileSystemGateway.readTextFile(path);
         const hashKey = ObjUtil.hash(content);
         const cache = this.cacheService.get('cache:srt', hashKey);

--- a/src/backend/services/TranscriptionService.ts
+++ b/src/backend/services/TranscriptionService.ts
@@ -380,7 +380,6 @@ export class LocalTranscriptionServiceImpl implements TranscriptionService {
         let tempFolder: string | null = null;
 
         try {
-            await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(filePath);
             // 开始
             await this.sendProgress(0, filePath, TranscriptTaskState.INIT, 0);
             if (signal.aborted) throw new CancelByUserError('Transcription cancelled by user');
@@ -521,7 +520,6 @@ export class LocalTranscriptionServiceImpl implements TranscriptionService {
         if (lines.length === 0) throw new Error('Parakeet v3 未识别出可用字幕');
         const finalSrt = serializeSrt(lines, { reindex: true });
         const srtFileName = filePath.replace(/\.[^/.]+$/, '') + '.srt';
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(srtFileName);
         await this.fileSystemGateway.writeTextFile(srtFileName, finalSrt);
 
         await this.sendProgress(0, filePath, TranscriptTaskState.DONE, 100, { srtPath: srtFileName });

--- a/src/backend/services/VideoLearningService.ts
+++ b/src/backend/services/VideoLearningService.ts
@@ -367,6 +367,27 @@ export class VideoLearningServiceImpl implements VideoLearningService {
     }
 
     /**
+     * 向用户汇总提示无法读取的单词视频片段数量。
+     *
+     * 行为说明：
+     * - 单条损坏不阻断列表展示，健康的片段照常返回；
+     * - 提示去重，避免每次刷新列表都重复弹窗。
+     *
+     * @param failedKeys 元数据损坏、无法读取的片段 key。
+     */
+    private notifyCorruptClips(failedKeys: string[]): void {
+        if (failedKeys.length === 0) {
+            return;
+        }
+        this.rendererGateway.fireAndForget('ui/show-toast', {
+            message: `有 ${failedKeys.length} 条单词视频片段无法读取，已跳过；详情见日志`,
+            variant: 'warning',
+            duration: 5000,
+            dedupeKey: 'video-learning-clip-corrupt',
+        });
+    }
+
+    /**
      * 裁切视频片段并写入对象存储和本地索引。
      *
      * @param task 待新增的片段任务。
@@ -723,10 +744,11 @@ export class VideoLearningServiceImpl implements VideoLearningService {
             });
 
             if (lines.length > 0) {
-                const ossMetas = await Promise.all(
-                    lines.map((line) => this.videoLearningOssService.get(line.key))
+                const { clips: ossMetas, failedKeys } = await this.videoLearningOssService.getAll(
+                    lines.map((line) => line.key)
                 );
-                const completedClips = ossMetas.filter((m): m is OssBaseMeta & ClipMeta => m !== null);
+                this.notifyCorruptClips(failedKeys);
+                const completedClips = ossMetas;
                 const completedWithSourceType = completedClips.map(clip => ({
                     ...clip,
                     sourceType: 'oss' as const
@@ -810,13 +832,11 @@ export class VideoLearningServiceImpl implements VideoLearningService {
     public async syncFromOss() {
         await concurrency.withMutex('video-learning-sync', async () => {
             const keys = await this.videoLearningOssService.list();
+            const { clips: metas, failedKeys } = await this.videoLearningOssService.getAll(keys);
+            this.notifyCorruptClips(failedKeys);
             const clips: InsertVideoLearningClip[] = [];
             const wordRelations: InsertVideoLearningClipWord[] = [];
-            for (const key of keys) {
-                const clip = await this.videoLearningOssService.get(key);
-                if (!clip) {
-                    continue;
-                }
+            for (const clip of metas) {
                 const srtLines = clip.clip_content ?? [];
                 const srtContext = srtLines.filter(e => !e.isClip).map(e => e.contentEn).join('\n');
                 const srtClip = srtLines.filter(e => e.isClip).map(e => e.contentEn).join('\n');

--- a/src/backend/services/WatchHistoryLibrary.ts
+++ b/src/backend/services/WatchHistoryLibrary.ts
@@ -44,7 +44,6 @@ export default class WatchHistoryLibrary {
     public async create(filePaths: string[]): Promise<string[]> {
         const existingPaths: string[] = [];
         for (const filePath of filePaths) {
-            await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(filePath);
             if (!await this.fileSystemGateway.pathIsMissing(filePath)) {
                 existingPaths.push(filePath);
             }
@@ -76,7 +75,6 @@ export default class WatchHistoryLibrary {
      * @returns 新建或已存在的观看记录 ID。
      */
     public async scanFolder(folder: string): Promise<string[]> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(folder);
         if (!await this.fileSystemGateway.directoryExists(folder)) {
             return [];
         }
@@ -103,7 +101,6 @@ export default class WatchHistoryLibrary {
         videoPath: string,
         projectType: WatchHistoryProjectType = WatchHistoryProjectType.FILE,
     ): Promise<string[]> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(videoPath);
         if (!await this.fileSystemGateway.fileExists(videoPath)) {
             return [];
         }

--- a/src/backend/services/WatchHistoryService.ts
+++ b/src/backend/services/WatchHistoryService.ts
@@ -139,7 +139,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
         this.watchHistoryViewBuilder = new WatchHistoryViewBuilder(
             mediaService,
             watchHistoryExtRepository,
-            storageDirectoryProvider,
             fileSystemGateway,
         );
     }
@@ -166,7 +165,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
                 return [];
             }
             if (refreshFolder) {
-                await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(folderPath);
                 if (!await this.fileSystemGateway.directoryExists(folderPath)) {
                     return [];
                 }
@@ -333,7 +331,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
      * @param srtPath 字幕路径；传入 `same` 时使用同名 SRT。
      */
     public async attachSrt(videoPath: string, srtPath: string | 'same'): Promise<void> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(videoPath);
         if (srtPath === 'same') {
             srtPath = path.join(path.dirname(videoPath), path.basename(videoPath, path.extname(videoPath)) + '.srt');
         }
@@ -493,7 +490,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
      */
     private async attachSrtInner(videoPath: string, srtPath: string): Promise<void> {
         videoPath = await this.watchHistoryLibrary.preferHtml5VideoPath(videoPath);
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(videoPath);
         if (!await this.fileSystemGateway.fileExists(videoPath)) {
             return;
         }
@@ -505,8 +501,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
         if (path.dirname(srtPath) === '.') {
             srtPath = path.join(folder, srtPath);
         }
-
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(srtPath);
         if (!await this.fileSystemGateway.fileExists(srtPath)) {
             return;
         }
@@ -530,7 +524,6 @@ export class WatchHistoryServiceImpl implements WatchHistoryService {
      */
     public async suggestSrt(file: string): Promise<string[]> {
         file = await this.watchHistoryLibrary.preferHtml5VideoPath(file);
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(file);
         const folder = path.dirname(file);
         const files = await this.fileSystemGateway.listFileNames(folder);
         const srtInFolder = files.filter(file => MediaUtil.isSubtitle(file))

--- a/src/backend/services/WatchHistoryViewBuilder.ts
+++ b/src/backend/services/WatchHistoryViewBuilder.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import MediaService from '@/backend/services/MediaService';
 import { WatchHistoryRecord } from '@/backend/services/repositories/WatchHistoryRepository';
 import WatchHistoryExtRepository from '@/backend/services/repositories/WatchHistoryExtRepository';
-import StorageDirectoryProvider from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import MatchSrt from '@/backend/utils/MatchSrt';
 import MediaUtil from '@/common/utils/MediaUtil';
 import StrUtil from '@/common/utils/str-util';
@@ -22,13 +21,11 @@ export default class WatchHistoryViewBuilder {
      *
      * @param mediaService 媒体信息服务。
      * @param watchHistoryExtRepository 观看历史扩展信息仓储。
-     * @param storageDirectoryProvider 存储目录与访问权限提供器。
      * @param fileSystemGateway 文件系统访问入口。
      */
     public constructor(
         private readonly mediaService: MediaService,
         private readonly watchHistoryExtRepository: WatchHistoryExtRepository,
-        private readonly storageDirectoryProvider: StorageDirectoryProvider,
         private readonly fileSystemGateway: FileSystemGateway,
     ) {
     }
@@ -61,7 +58,6 @@ export default class WatchHistoryViewBuilder {
      */
     public async buildPlayerDetail(history: WatchHistoryRecord): Promise<WatchHistoryVO | null> {
         const filePath = path.join(history.base_path, history.file_name);
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(filePath);
         if (!await this.fileSystemGateway.fileExists(filePath)) {
             return null;
         }
@@ -119,7 +115,6 @@ export default class WatchHistoryViewBuilder {
     private async resolveSubtitle(history: WatchHistoryRecord, videoPath: string): Promise<string> {
         const configuredSubtitle = history.srt_file;
         if (StrUtil.isNotBlank(configuredSubtitle)) {
-            await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(configuredSubtitle);
             const exists = await this.fileSystemGateway.fileExists(configuredSubtitle);
             if (exists) {
                 return configuredSubtitle;
@@ -141,7 +136,6 @@ export default class WatchHistoryViewBuilder {
      */
     public async resolveSubtitleForPlayback(history: WatchHistoryRecord): Promise<string | null> {
         const videoPath = path.join(history.base_path, history.file_name);
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(videoPath);
         if (!await this.fileSystemGateway.fileExists(videoPath)) {
             return null;
         }
@@ -155,7 +149,6 @@ export default class WatchHistoryViewBuilder {
      * @returns 字幕文件绝对路径列表。
      */
     private async listSubtitleFiles(folder: string): Promise<string[]> {
-        await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(folder);
         const fileNames = await this.fileSystemGateway.listFileNames(folder);
         const subtitlePaths = fileNames
             .filter((fileName) => MediaUtil.isSubtitle(fileName))


### PR DESCRIPTION
## 背景

文件操作治理的收尾 PR，补齐 #205 遗留的三件事：

1. #205 把 `get()` 对损坏元数据改为抛错后，上层 `Promise.all` 一坏全坏——一条坏数据会让整个收藏列表/同步流程报错
2. #206 的网关装饰器上线后，11 个服务里 35 处手动 `ensurePathAccessPermissionIfExists` 大部分成了冗余调用
3. “业务代码文件访问统一走网关”缺少文档约定

## 改动（三个提交）

**批量读取逐条容错**
- `OssService` 新增 `getAll`：不存在的 key 静默跳过；元数据损坏只影响当条，记错误日志并计入 `failedKeys`，不抛出
- `FavouriteClipsService.search/syncFromOss`、`VideoLearningService` 分页/sync 改用 `getAll`：健康片段照常展示，损坏条目经 `ui/show-toast` 去重提示“N 条无法读取，已跳过”
- `taskAddOperation` 写后即读保持严格抛错（自己刚写的读不回来必须暴露）

**冗余权限确认清理**（逐处核对后删 22 处）
- WatchHistory 全家：每处 ensure 后均有同路径网关调用，播放路径返回 renderer 前必经 `fileExists` 校验，装饰器自动覆盖
- Convert/Split/Media/Subtitle/Transcription/AiFunc：或走网关，或由 `FfmpegService` 收口点覆盖（转录媒体仅经 ffmpeg 消耗）
- 保留 `FfmpegService` 全部 21 处：ffmpeg/ffprobe 是外部进程消费者，不经过网关
- 五个服务的 `storageDirectoryProvider` 注入随调用清零移除

**文档约定**
- `architecture-guidelines.md` 新增 2.5 文件访问：统一走网关、权限自动恢复、例外清单（外部进程网关/基础设施自举/内置资源/流式下载解压）

## 验证步骤

- [x] 存储层测试 25/25（含新增 `getAll` 容错 2 用例）；全量与基线一致（仅 TagService 存量 ABI）
- [x] `npx tsc --noEmit`、`yarn lint` 无新增问题
- [ ] 真机验证：收藏列表/单词视频列表在存在坏片段时正常展示并弹提示；macOS 收回目录授权后播放/转录/转换仍能弹窗恢复

> 堆叠说明：基于 #207，合并顺序 #205 → #206 → #207 → 本 PR。合并后文件操作治理线闭环：统一入口 + 异步 + 自动权限 + 容错 + 约定文档。