### PR TITLE
feat: 收藏片段页当前句接入单词级词典弹窗与生词高亮

### DIFF
--- a/src/backend/controllers/SubtitleController.ts
+++ b/src/backend/controllers/SubtitleController.ts
@@ -1,5 +1,6 @@
 import registerRoute from '@/backend/controllers/ipc/registerRoute';
 import { SrtSentence } from '@/common/types/SentenceC';
+import { SentenceStruct } from '@/common/types/SentenceStruct';
 import { inject, injectable } from 'inversify';
 import TYPES from '@/backend/ioc/types';
 import Controller from '@/backend/controllers/Controller';
@@ -51,10 +52,21 @@ export default class SubtitleController implements Controller {
     }
 
     /**
+     * 将任意英文文本解析为前端展示结构。
+     *
+     * @param texts 待解析文本数组。
+     * @returns 与入参顺序一一对应的结构化句子。
+     */
+    public async parseStructs(texts: string[]): Promise<SentenceStruct[]> {
+        return this.subtitleService.parseStructs(texts);
+    }
+
+    /**
      * 注册字幕相关 IPC 路由。
      */
     registerRoutes(): void {
         registerRoute('subtitle/srt/parse-to-sentences', (p) => this.parseSrt(p));
         registerRoute('subtitle/srt/match-vocabulary', (p) => this.matchVocabulary(p));
+        registerRoute('subtitle/text/parse-structs', (p) => this.parseStructs(p));
     }
 }

--- a/src/backend/services/SubtitleService.ts
+++ b/src/backend/services/SubtitleService.ts
@@ -104,6 +104,16 @@ export default interface SubtitleService {
     ): Promise<SubtitleVocabularyMatchResult>;
 
     /**
+     * 将任意英文文本解析为前端展示结构（分词、lemma、词性）。
+     *
+     * 用于非字幕文件场景（如收藏片段列表）获取与播放器一致的单词级结构。
+     *
+     * @param texts 待解析文本数组，返回结果与入参顺序一一对应。
+     * @returns 结构化句子数组。
+     */
+    parseStructs(texts: string[]): SentenceStruct[];
+
+    /**
      * 词表变化后清除共享字幕生词分析缓存。
      */
     invalidateVocabularyAnalysisCache(): void;
@@ -359,6 +369,11 @@ export class SubtitleServiceImpl implements SubtitleService {
      */
     public invalidateVocabularyAnalysisCache(): void {
         this.vocabularyAnalysisService.invalidate();
+    }
+
+    /** {@inheritDoc SubtitleService.parseStructs} */
+    public parseStructs(texts: string[]): SentenceStruct[] {
+        return texts.map((text) => this.processSentence(text));
     }
 
     /**

--- a/src/common/api/api-def.ts
+++ b/src/common/api/api-def.ts
@@ -2,6 +2,7 @@ import {DpTask} from '@/common/contracts/dp-task';
 import {YdRes, OpenAIDictionaryResult} from '@/common/types/YdRes';
 import {ChapterParseResult} from '@/common/types/chapter-result';
 import {SrtSentence, Sentence} from '@/common/types/SentenceC';
+import {SentenceStruct} from '@/common/types/SentenceStruct';
 import {WindowState} from '@/common/types/Types';
 import {SubtitleTimestampAdjustmentInput} from '@/common/contracts/subtitle-timestamp-adjustment';
 import { UpdateCheckResult } from '@/common/types/update-check';
@@ -205,6 +206,10 @@ interface SubtitleControllerDef {
             vocabularyWords: string[];
             cancelled: boolean;
         };
+    };
+    'subtitle/text/parse-structs': {
+        params: string[];
+        return: SentenceStruct[];
     };
 }
 

--- a/src/common/utils/subtitle/sentence.ts
+++ b/src/common/utils/subtitle/sentence.ts
@@ -59,14 +59,17 @@ export function srtLineToSentence(
  * @param clipSrtLines 片段字幕行。
  * @param videoPath 源视频路径。
  * @param clipKey 片段稳定键，用作文件哈希。
+ * @param structs 可选的句法解析结果，与 clipSrtLines 顺序一一对应；
+ *        未提供时退化为无分词结构（整句纯文本渲染，不具备单词级交互）。
  * @returns 播放器句子数组。
  */
 export function clipLinesToSentences(
     clipSrtLines: ClipSrtLine[],
     videoPath: string,
-    clipKey: string
+    clipKey: string,
+    structs?: SentenceStruct[]
 ): Sentence[] {
-    return clipSrtLines.map((line) => ({
+    return clipSrtLines.map((line, position) => ({
         fileHash: clipKey,
         filePath: videoPath,
         index: line.index,
@@ -79,6 +82,6 @@ export function clipLinesToSentences(
         key: `${clipKey}-${line.index}`,
         transGroup: 1,
         translationKey: `${clipKey}:${line.index}`,
-        struct: { original: line.contentEn, blocks: [] } as SentenceStruct
+        struct: structs?.[position] ?? ({ original: line.contentEn, blocks: [] } as SentenceStruct)
     }));
 }

--- a/src/fronted/features/favourite/FavouritePage.tsx
+++ b/src/fronted/features/favourite/FavouritePage.tsx
@@ -14,6 +14,11 @@ import { apiPath, swrApiMutate } from '@/fronted/lib/swr-util';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import useFavouriteClip from '@/fronted/features/favourite/favouriteStore';
 import { favouriteApi } from '@/fronted/features/favourite/favouriteApi';
+import useVocabulary from '@/fronted/features/player/vocabularyStore';
+import { videoLearningApi } from '@/fronted/features/video-learning/videoLearningApi';
+import { getRendererLogger } from '@/fronted/log/simple-logger';
+
+const logger = getRendererLogger('FavouritePage');
 import toast from 'react-hot-toast';
 import { Button } from '@/fronted/components/ui/button';
 import PageHeader from '@/fronted/components/shared/common/PageHeader';
@@ -74,6 +79,29 @@ const Favorite = () => {
     });
 
     const playInfo = useFavouriteClip((state) => state.playInfo);
+
+    // 进入收藏页时用用户完整生词表驱动列表高亮；离开后由各页面（播放器/词汇工坊）自行重建。
+    useEffect(() => {
+        let cancelled = false;
+        videoLearningApi.getVocabulary().then((result) => {
+            if (cancelled || !result.success || !Array.isArray(result.data)) {
+                return;
+            }
+            const words = (result.data as { word: string }[])
+                .map((row) => row.word)
+                .filter((word): word is string => !!word);
+            // 同步清空词形映射，避免残留上一页面的形态数据干扰命中判断。
+            useVocabulary.getState().setVocabularyForms({});
+            useVocabulary.getState().setVocabularyWords(words);
+        }).catch((error) => {
+            logger.error('failed to load vocabulary for favourite page', {
+                error: error instanceof Error ? error.message : error
+            });
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     /**
      * 从本地 Saved Moments 文件夹重建索引。

--- a/src/fronted/features/favourite/components/FavouriteMainSrt.tsx
+++ b/src/fronted/features/favourite/components/FavouriteMainSrt.tsx
@@ -23,7 +23,7 @@ const FavouriteMainSrt = () => {
           className="w-full max-w-full text-base sm:text-lg md:text-xl font-medium tracking-tight text-foreground leading-relaxed break-words whitespace-normal px-2 text-center"
           wordClassNames={{
             hover: 'hover:bg-primary/20 rounded px-0.5 transition-colors',
-            vocab: '!text-purple-600 dark:!text-purple-400 !underline !decoration-purple-500 !decoration-1 !bg-purple-500/10 px-1 py-0.5 rounded font-semibold hover:!bg-purple-500/25'
+            vocab: 'text-purple-700 dark:text-purple-400 font-medium underline decoration-purple-500/50 dark:decoration-purple-400/40 decoration-[1.5px] underline-offset-[0.22em] rounded px-0.5 transition-colors duration-150 hover:bg-purple-500/10 dark:hover:bg-purple-400/10 hover:decoration-purple-600 dark:hover:decoration-purple-300'
           }}
         />
       </div>

--- a/src/fronted/features/favourite/components/FavouritePlayer.tsx
+++ b/src/fronted/features/favourite/components/FavouritePlayer.tsx
@@ -19,6 +19,7 @@ import TimeUtil from '@/common/utils/TimeUtil';
 import UrlUtil from '@/common/utils/UrlUtil';
 import { getRendererLogger } from '@/fronted/log/simple-logger';
 import { favouriteApi } from '@/fronted/features/favourite/favouriteApi';
+import { playerApi } from '@/fronted/features/player/playerApi';
 
 const logger = getRendererLogger('FavouritePlayer');
 
@@ -88,14 +89,29 @@ const FavouritePlayer = () => {
 
     if (!isSameClip) {
       playerActions.setSource(videoUrl);
-
-      if (video.clip_content) {
-        const sentencesConv = clipLinesToSentences(video.clip_content, videoKey, videoKey);
-        playerActions.loadSubtitles(sentencesConv);
-      }
       loadedKeyRef.current = videoKey;
       window.setTimeout(() => setReady(false), 0);
       bootOnceRef.current = false;
+
+      if (video.clip_content) {
+        const clipContent = video.clip_content;
+        // 先向后端取回句法结构，再加载字幕，使当前句支持单词级词典弹窗与生词高亮。
+        playerApi.parseTextStructs(clipContent.map((line) => line.contentEn))
+          .then((structs) => {
+            // 解析期间可能已切到其它片段，迟到结果不再加载。
+            if (loadedKeyRef.current !== videoKey) {
+              return;
+            }
+            const sentencesConv = clipLinesToSentences(clipContent, videoKey, videoKey, structs);
+            playerActions.loadSubtitles(sentencesConv);
+          })
+          .catch((error) => {
+            logger.error('failed to parse clip sentence structs', {
+              videoKey,
+              error: error instanceof Error ? error.message : error
+            });
+          });
+      }
       logger.debug('Loaded new clip', { key: videoKey });
     } else {
       if (ready) {

--- a/src/fronted/features/player/playerApi.ts
+++ b/src/fronted/features/player/playerApi.ts
@@ -165,6 +165,15 @@ export const playerApi = {
     }) => backendClient.call('subtitle/srt/match-vocabulary', params),
 
     /**
+     * 将任意英文文本解析为单词级展示结构（分词、lemma、词性）。
+     *
+     * @param texts 待解析文本数组。
+     * @returns 与入参顺序一一对应的结构化句子。
+     */
+    parseTextStructs: (texts: string[]) =>
+        backendClient.call('subtitle/text/parse-structs', texts),
+
+    /**
      * 更新播放进度。
      *
      * @param params 播放进度参数。


### PR DESCRIPTION
## 背景

收藏片段页右侧当前句（`FavouriteMainSrt`）此前拿到的是空句法结构，只能纯文本展示，无法像主字幕播放器的主字幕行那样做单词级交互（词典弹窗、生词高亮、点词发音、收藏单词）。本 PR 让当前句获得与主播放器一致的交互能力；**左侧片段列表保持纯文本展示不变**。

## 改动内容

**后端**
- 新增 `subtitle/text/parse-structs` IPC 接口（`SubtitleService.parseStructs`）：把任意英文文本解析为与播放器字幕一致的句法结构（分词、lemma、词性），复用同一套 wink 解析逻辑。

**前端**
- `FavouritePlayer`：加载片段时先取回句法结构再 `loadSubtitles`（带竞态保护，切片段后迟到结果不再加载），右侧当前句原本就在渲染 `TranslatableLine`，只是拿到的是空结构，链路打通后自动获得完整单词交互。
- `FavouritePage`：挂载时装载用户完整生词表驱动当前句高亮，同时清空残留的词形映射，避免上一页面的脏数据干扰命中判断；离开后播放器/词汇工坊挂载时自行重建，互不污染。
- `clipLinesToSentences` 增加可选 `structs` 参数，未提供时保持原有纯文本行为（词汇工坊现有调用不受影响）。

## 验证步骤

1. `npx tsc --noEmit`：无新增错误（`preload.ts` 的 `SimpleEvent` 报错为 main 上既有问题）
2. `yarn lint`：无新增问题（`TagSelector` autoFocus、缩略图键盘监听为既有问题）
3. `yarn test:run`：25 个测试文件、185 个用例全部通过（10 个跳过为既有）
4. 手动验证（建议合并前过一遍）：
   - 打开收藏片段页并播放片段，右侧当前句的单词可 hover 弹词典、点击发音、收藏单词
   - 已加入生词表的单词在当前句显示紫色高亮
   - 快速切换片段时字幕加载正常，无串台
   - 左侧列表行为与改动前完全一致（纯文本，点击整行跳转播放）

## 备注

- UI 有交互流程变化，但词典弹窗为既有组件，建议合并前在本地实际跑一下弹窗定位效果。
- 无 drizzle 迁移，无需重新执行 `yarn run download`。