### PR TITLE
build: drizzle-kit 改用 Electron 运行时执行，规避 better-sqlite3 ABI 冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:base": "cross-env ELECTRON_RUN_AS_NODE=1 electron node_modules/vitest/vitest.mjs",
     "test:run": "run-s test:base -- run",
     "test:coverage": "run-s test:base -- run --coverage",
-    "test:watch": "run-s test:base -- watch"
+    "test:watch": "run-s test:base -- watch",
+    "drizzle-kit": "cross-env ELECTRON_RUN_AS_NODE=1 electron node_modules/drizzle-kit/bin.cjs"
   },
   "keywords": [],
   "author": {


### PR DESCRIPTION
## 背景

better-sqlite3 的原生二进制只能绑定一个 ABI：Electron 39.2.7 是 140，系统 Node 22 是 127，`node_modules` 里却只有一份 `better_sqlite3.node`。`yarn start` / `yarn package` 触发 forge rebuild 后二进制切到 140，此时用系统 Node 运行 drizzle-kit（`introspect` / `push` / `studio` / `migrate` 等会加载 better-sqlite3 的子命令）即报 `NODE_MODULE_VERSION 140 ... requires 127` 拒载——与 #198 中 vitest 的问题同源。

## 改动

`package.json` 新增一个 script，把 drizzle-kit 包一层 `ELECTRON_RUN_AS_NODE=1 electron`（与 `test:base` 完全同一写法）：

```json
"drizzle-kit": "cross-env ELECTRON_RUN_AS_NODE=1 electron node_modules/drizzle-kit/bin.cjs"
```

命令入口不变：`yarn drizzle-kit generate` 等用法照旧，只是统一在 Electron ABI 下执行。至此所有 SQLite 消费方（主进程 / vitest / drizzle-kit）都跑在同一个 ABI 上，不再随 rebuild 状态来回翻转。

升级 Electron / Node 无法根治该问题（Electron 的 `NODE_MODULE_VERSION` 永远与官方 Node 不同），统一运行时是社区标准做法（VS Code 同款模式）。

## 验证

- 模拟 forge rebuild 后（Electron ABI 140 二进制）：系统 Node 直接跑 `drizzle-kit migrate` 复现 `NODE_MODULE_VERSION 140` 报错；`yarn drizzle-kit migrate`（新命令）迁移应用成功（真实 dlopen 了 better-sqlite3 并写库）
- `yarn test:run`：24 个文件 173 条用例全绿（测试链路本就走 Electron 运行时，不受影响）
- 无依赖变更，`yarn.lock` 未动

## 备注

- 全新 `yarn install` 后二进制是 Node ABI（127），此时 Electron 侧由 `yarn start` 的 forge rebuild 自动纠正，属既有行为，本 PR 不改变
- 今后新增会加载 better-sqlite3 的 Node 侧脚本，应沿用同一包装写法