### PR TITLE
fix: 修复 FFmpeg 转码兼容性问题并重构字幕提取选流

### DIFF
--- a/src/backend/infrastructure/media/ffmpeg/FfmpegCommandBuilder.ts
+++ b/src/backend/infrastructure/media/ffmpeg/FfmpegCommandBuilder.ts
@@ -2,8 +2,7 @@ import TimeUtil from '@/common/utils/TimeUtil';
 import type {
     ConvertToWavArgs,
     CreateThumbnailArgs,
-    ExtractSubtitleArgs,
-    SplitAudioArgs,
+    ExtractSubtitleCommandArgs,
     SplitVideoByTimesArgs,
     SplitVideoRangeArgs,
     TrimAudioArgs,
@@ -37,14 +36,9 @@ export interface FfmpegCommandBuilder {
     buildThumbnail(args: CreateThumbnailArgs): string[];
 
     /**
-     * 构建字幕提取命令参数。
+     * 构建字幕提取命令参数；字幕流必须由网关探测选定后传入，避免命中图形字幕或多流。
      */
-    buildExtractSubtitle(args: ExtractSubtitleArgs): string[];
-
-    /**
-     * 构建音频分段命令参数。
-     */
-    buildSplitAudio(args: SplitAudioArgs): string[];
+    buildExtractSubtitle(args: ExtractSubtitleCommandArgs): string[];
 
     /**
      * 构建转 MP4 命令参数。
@@ -123,9 +117,16 @@ export class DefaultFfmpegCommandBuilder implements FfmpegCommandBuilder {
             '-i', args.inputFile,
             '-t', `${duration}`,
             '-c:v', videoCodec,
-            '-c:a', audioCodec,
-            '-crf', `${crf}`,
+            // 强制 8bit yuv420p：源为 10bit 时 libx264/x265 会离出 High10/Main10，浏览器普遍无法播放。
+            '-pix_fmt', 'yuv420p',
         ];
+
+        if (args.videoPreset) {
+            result.push('-preset', args.videoPreset);
+        }
+
+        result.push('-crf', `${crf}`);
+        result.push('-c:a', audioCodec);
 
         if (typeof args.audioChannels === 'number' && args.audioChannels > 0) {
             result.push('-ac', `${Math.floor(args.audioChannels)}`);
@@ -136,7 +137,8 @@ export class DefaultFfmpegCommandBuilder implements FfmpegCommandBuilder {
         }
 
         if (typeof args.outputWidth === 'number' && args.outputWidth > 0) {
-            result.push('-vf', `scale=${Math.floor(args.outputWidth)}:-1`);
+            // -2 保证高度取偶：libx264/x265 编码 yuv420p 要求宽高均为偶数，奇数高度会直接报错。
+            result.push('-vf', `scale=${Math.floor(args.outputWidth)}:-2`);
         }
 
         result.push(args.outputFile);
@@ -171,35 +173,15 @@ export class DefaultFfmpegCommandBuilder implements FfmpegCommandBuilder {
     }
 
     /**
-     * 构建字幕提取命令参数。
+     * 构建字幕提取命令参数；只映射探测选定的单条字幕流，避免多流写单文件报错。
      */
-    public buildExtractSubtitle(args: ExtractSubtitleArgs): string[] {
+    public buildExtractSubtitle(args: ExtractSubtitleCommandArgs): string[] {
         return [
             '-y',
             '-i', args.inputFile,
-            '-map', args.mapRule,
+            '-map', `0:${args.streamIndex}`,
             '-c:s', 'srt',
             args.outputFile,
-        ];
-    }
-
-    /**
-     * 构建音频分段命令参数。
-     */
-    public buildSplitAudio(args: SplitAudioArgs): string[] {
-        if (!Number.isFinite(args.segmentSecond) || args.segmentSecond <= 0) {
-            throw new Error('音频分段时长必须大于 0 秒');
-        }
-
-        return [
-            '-y',
-            '-i', args.inputFile,
-            '-vn',
-            '-f', 'segment',
-            '-segment_time', `${args.segmentSecond}`,
-            '-c:a', 'libmp3lame',
-            '-qscale:a', '4',
-            args.outputPattern,
         ];
     }
 
@@ -211,7 +193,10 @@ export class DefaultFfmpegCommandBuilder implements FfmpegCommandBuilder {
             '-y',
             '-i', inputFile,
             '-c:v', 'libx264',
+            // 强制 8bit yuv420p，保证产出在任何浏览器可播；与 mkvToMp4 一致补 faststart 便于流式播放。
+            '-pix_fmt', 'yuv420p',
             '-c:a', 'aac',
+            '-movflags', '+faststart',
             outputFile,
         ];
     }

--- a/src/backend/infrastructure/media/ffmpeg/FfmpegGatewayImpl.ts
+++ b/src/backend/infrastructure/media/ffmpeg/FfmpegGatewayImpl.ts
@@ -5,7 +5,6 @@ import FfmpegGateway, {
     ExtractSubtitleArgs,
     FfmpegExecutionError,
     FfmpegRunOptions,
-    SplitAudioArgs,
     SplitVideoByTimesArgs,
     SplitVideoRangeArgs,
     TrimAudioArgs,
@@ -22,13 +21,17 @@ import { FfmpegProcessRunner } from '@/backend/infrastructure/media/ffmpeg/Ffmpe
 import { getRuntimeResourcePath } from '@/backend/utils/runtimeEnv';
 
 /**
- * FFprobe 视频流元数据。
+ * FFprobe 流元数据。
  */
 interface FfprobeStream {
-    /** 流类型，例如 video 或 audio。 */
+    /** 流在输入媒体中的绝对索引，用于 -map 精确选流。 */
+    index?: number;
+    /** 流类型，例如 video、audio 或 subtitle。 */
     codec_type?: string;
-    /** 编码器名称，例如 h264。 */
+    /** 编码器名称，例如 h264、subrip、hdmv_pgs_subtitle。 */
     codec_name?: string;
+    /** 容器标签，MKV 等格式的语言信息存在这里。 */
+    tags?: { language?: string };
 }
 
 /**
@@ -69,6 +72,17 @@ type FfmpegCommandTarget = {
     outputFile?: string;
     outputPattern?: string;
 };
+
+/**
+ * 可转 srt 的文本字幕编码器白名单。
+ *
+ * PGS/DVB 等图形字幕无法转文本，命中它们时 ffmpeg 会报“Subtitle codec not supported”；
+ * 提取前先按此名单筛掉图形字幕，无文本字幕时直接返回“未提取到”。
+ */
+const TEXT_SUBTITLE_CODECS = new Set([
+    'subrip', 'srt', 'ass', 'ssa', 'webvtt', 'mov_text', 'text', 'sami',
+    'microdvd', 'subviewer', 'vplayer', 'mpl2', 'realtext', 'stl', 'pjs', 'jacosub',
+]);
 
 /**
  * FFmpeg 基础设施网关实现。
@@ -163,10 +177,42 @@ export default class FfmpegGatewayImpl implements FfmpegGateway {
     }
 
     /**
-     * 分段音频。
+     * 提取文本字幕；先用 ffprobe 选定单条文本字幕流，无候选时返回 false。
      */
-    public async splitAudio(args: SplitAudioArgs, options: FfmpegRunOptions = {}): Promise<void> {
-        await this.runCommand(args, (a) => this.commandBuilder.buildSplitAudio(a), options);
+    public async extractSubtitles(args: ExtractSubtitleArgs, options: FfmpegRunOptions = {}): Promise<boolean> {
+        this.assertInputFileExists(args.inputFile);
+        const streamIndex = this.selectTextSubtitleStream(
+            (await this.probe(args.inputFile)).streams,
+            args.preferLanguage,
+        );
+        if (streamIndex === undefined) {
+            return false;
+        }
+
+        await this.runCommand(
+            { inputFile: args.inputFile, outputFile: args.outputFile, streamIndex },
+            (a) => this.commandBuilder.buildExtractSubtitle(a),
+            options,
+        );
+        return true;
+    }
+
+    /**
+     * 从探测到的流列表中选定唯一文本字幕流：优先匹配偏好语言，否则取第一条。
+     * @param streams ffprobe 探测到的流列表。
+     * @param preferLanguage 偏好语言标签（如 eng）。
+     * @returns 选定流的绝对索引；无文本字幕时返回 undefined。
+     */
+    private selectTextSubtitleStream(streams: FfprobeStream[], preferLanguage?: string): number | undefined {
+        const textSubtitles = streams.filter((stream) =>
+            stream.codec_type === 'subtitle'
+            && typeof stream.index === 'number'
+            && typeof stream.codec_name === 'string'
+            && TEXT_SUBTITLE_CODECS.has(stream.codec_name));
+        const preferred = preferLanguage
+            ? textSubtitles.find(stream => stream.tags?.language === preferLanguage)
+            : undefined;
+        return (preferred ?? textSubtitles[0])?.index;
     }
 
     /**
@@ -189,13 +235,6 @@ export default class FfmpegGatewayImpl implements FfmpegGateway {
             (a) => this.commandBuilder.buildMkvToMp4(a.inputFile, a.outputFile),
             options,
         );
-    }
-
-    /**
-     * 提取字幕。
-     */
-    public async extractSubtitles(args: ExtractSubtitleArgs, options: FfmpegRunOptions = {}): Promise<void> {
-        await this.runCommand(args, (a) => this.commandBuilder.buildExtractSubtitle(a), options);
     }
 
     /**

--- a/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegCommandBuilder.test.ts
+++ b/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegCommandBuilder.test.ts
@@ -66,6 +66,40 @@ describe('DefaultFfmpegCommandBuilder', () => {
         expect(args).toContain('64k');
     });
 
+    it('裁剪视频缩放时应取偶数高度并强制 yuv420p，避免奇数高度编码报错', () => {
+        const args = builder.buildTrimVideo({
+            inputFile: '/in.mp4',
+            outputFile: '/out.mp4',
+            startSecond: 1,
+            endSecond: 3,
+            outputWidth: 641,
+            videoPreset: 'veryfast',
+        });
+
+        expect(args).toContain('-vf');
+        expect(args).toContain('scale=641:-2');
+        expect(args).toContain('-pix_fmt');
+        expect(args).toContain('yuv420p');
+        expect(args).toContain('-preset');
+        expect(args).toContain('veryfast');
+    });
+
+    it('提取字幕时应只映射探测选定的单条字幕流', () => {
+        const args = builder.buildExtractSubtitle({
+            inputFile: '/in.mkv',
+            outputFile: '/out.srt',
+            streamIndex: 2,
+        });
+
+        expect(args).toEqual([
+            '-y',
+            '-i', '/in.mkv',
+            '-map', '0:2',
+            '-c:s', 'srt',
+            '/out.srt',
+        ]);
+    });
+
     it('生成 jpg 缩略图时应注入 qscale 参数', () => {
         const args = builder.buildThumbnail({
             inputFile: '/input.mp4',
@@ -91,24 +125,16 @@ describe('DefaultFfmpegCommandBuilder', () => {
         expect(args).not.toContain('-q:v');
     });
 
-    it('音频分段时长小于等于零时应抛错', () => {
-        expect(() => {
-            builder.buildSplitAudio({
-                inputFile: '/in.mp4',
-                segmentSecond: 0,
-                outputPattern: '/tmp/seg_%03d.mp3',
-            });
-        }).toThrow('音频分段时长必须大于 0 秒');
-    });
-
-    it('构建转 mp4 参数时应包含默认编码器', () => {
+    it('构建转 mp4 参数时应包含浏览器兼容所需的像素格式与 faststart', () => {
         const args = builder.buildToMp4('/in.mkv', '/out.mp4');
 
         expect(args).toEqual([
             '-y',
             '-i', '/in.mkv',
             '-c:v', 'libx264',
+            '-pix_fmt', 'yuv420p',
             '-c:a', 'aac',
+            '-movflags', '+faststart',
             '/out.mp4',
         ]);
     });

--- a/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegGatewayImpl.test.ts
+++ b/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegGatewayImpl.test.ts
@@ -52,7 +52,6 @@ function createGateway(probeStdout = JSON.stringify({ format: { duration: 66.6 }
         buildTrimVideo: vi.fn(() => ['-trim-video']),
         buildThumbnail: vi.fn(() => ['-thumbnail']),
         buildExtractSubtitle: vi.fn(() => ['-extract-sub']),
-        buildSplitAudio: vi.fn(() => ['-split-audio']),
         buildToMp4: vi.fn(() => ['-to-mp4']),
         buildMkvToMp4: vi.fn(() => ['-mkv-to-mp4']),
         buildConvertToWav: vi.fn(() => ['-to-wav']),
@@ -217,6 +216,71 @@ describe('FfmpegGatewayImpl', () => {
 
         expect(deps.runMock).not.toHaveBeenCalled();
         expect(deps.startMock.mock.calls[0][0].inputDurationSecond).toBe(99);
+    });
+
+    it('extractSubtitles 有偏好语言的文本字幕时应优先选它并返回 true', async () => {
+        const { gateway, deps } = createGateway(JSON.stringify({
+            format: { duration: 66.6 },
+            streams: [
+                { index: 0, codec_type: 'video', codec_name: 'h264' },
+                { index: 1, codec_type: 'audio', codec_name: 'aac' },
+                { index: 2, codec_type: 'subtitle', codec_name: 'subrip', tags: { language: 'chi' } },
+                { index: 3, codec_type: 'subtitle', codec_name: 'subrip', tags: { language: 'eng' } },
+            ],
+        }));
+
+        const extracted = await gateway.extractSubtitles({
+            inputFile: inputFilePath,
+            outputFile: path.join(workDir, 'out.srt'),
+            preferLanguage: 'eng',
+        });
+
+        expect(extracted).toBe(true);
+        expect(deps.commandBuilder.buildExtractSubtitle).toHaveBeenCalledWith({
+            inputFile: inputFilePath,
+            outputFile: path.join(workDir, 'out.srt'),
+            streamIndex: 3,
+        });
+        expect(deps.startMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('extractSubtitles 只有图形字幕时应返回 false 且不启动 ffmpeg', async () => {
+        const { gateway, deps } = createGateway(JSON.stringify({
+            format: { duration: 66.6 },
+            streams: [
+                { index: 0, codec_type: 'video', codec_name: 'h264' },
+                { index: 1, codec_type: 'subtitle', codec_name: 'hdmv_pgs_subtitle', tags: { language: 'eng' } },
+            ],
+        }));
+
+        const extracted = await gateway.extractSubtitles({
+            inputFile: inputFilePath,
+            outputFile: path.join(workDir, 'out.srt'),
+        });
+
+        expect(extracted).toBe(false);
+        expect(deps.startMock).not.toHaveBeenCalled();
+    });
+
+    it('extractSubtitles 无偏好语言匹配时应回退第一条文本字幕', async () => {
+        const { gateway, deps } = createGateway(JSON.stringify({
+            format: { duration: 66.6 },
+            streams: [
+                { index: 2, codec_type: 'subtitle', codec_name: 'subrip' },
+                { index: 3, codec_type: 'subtitle', codec_name: 'ass', tags: { language: 'eng' } },
+            ],
+        }));
+
+        const extracted = await gateway.extractSubtitles({
+            inputFile: inputFilePath,
+            outputFile: path.join(workDir, 'out.srt'),
+            preferLanguage: 'jpn',
+        });
+
+        expect(extracted).toBe(true);
+        expect(deps.commandBuilder.buildExtractSubtitle).toHaveBeenCalledWith(
+            expect.objectContaining({ streamIndex: 2 }),
+        );
     });
 
     it('应把 runner 进度回调映射为向下取整的百分比', async () => {

--- a/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegSmoke.test.ts
+++ b/src/backend/infrastructure/media/ffmpeg/__tests__/FfmpegSmoke.test.ts
@@ -205,19 +205,6 @@ describe.skipIf(!binariesReady)('ffmpeg 网关冒烟测试（真实执行）', (
         expect(Number(probe.format.duration)).toBeLessThan(1.3);
     });
 
-    it('splitAudio 按 1 秒分段应产出多段 mp3', { timeout: 60_000 }, async () => {
-        const outputPattern = path.join(workDir, 'seg_%03d.mp3');
-
-        await gateway.splitAudio({
-            inputFile: sampleVideo,
-            segmentSecond: 1,
-            outputPattern,
-        });
-
-        const segments = fs.readdirSync(workDir).filter(file => file.startsWith('seg_'));
-        expect(segments.length).toBeGreaterThanOrEqual(2);
-    });
-
     it('toMp4 重封装转码后应仍可探测出音视频流', { timeout: 60_000 }, async () => {
         const outputFile = path.join(workDir, 'to-mp4.mp4');
 
@@ -261,13 +248,26 @@ describe.skipIf(!binariesReady)('ffmpeg 网关冒烟测试（真实执行）', (
         ]);
 
         const outputFile = path.join(workDir, 'extracted.srt');
-        await gateway.extractSubtitles({
+        const extracted = await gateway.extractSubtitles({
             inputFile: mkvFile,
             outputFile,
-            mapRule: '0:s:0?',
+            preferLanguage: 'eng',
         });
 
+        expect(extracted).toBe(true);
         const content = await fs.promises.readFile(outputFile, 'utf8');
         expect(content).toContain('Hello smoke test');
+    });
+
+    it('extractSubtitles 在无字幕的媒体上应返回 false 且不产出文件', { timeout: 30_000 }, async () => {
+        const outputFile = path.join(workDir, 'no-sub.srt');
+
+        const extracted = await gateway.extractSubtitles({
+            inputFile: sampleVideo,
+            outputFile,
+        });
+
+        expect(extracted).toBe(false);
+        expect(fs.existsSync(outputFile)).toBe(false);
     });
 });

--- a/src/backend/services/ConvertService.ts
+++ b/src/backend/services/ConvertService.ts
@@ -206,9 +206,10 @@ export class ConvertServiceImpl implements ConvertService {
     }
 
     /**
-     * 尝试提取字幕；媒体中没有可用字幕时不影响视频转换结果。
+     * 提取字幕；无文本字幕或提取结果为空时返回 false，不影响视频转换结果。
      *
-     * 先尝试英语字幕轨道，未生成有效文件时再尝试第一条字幕轨道。
+     * 字幕流选择（优先英语、回退第一条文本字幕）由 FFmpeg 服务层一次性完成，
+     * 不再采用“跑失败再重试下一条轨道”的猜测式两段回退。
      * 用户取消必须继续向上抛出，由任务流程标记为已取消。
      *
      * @param taskId 转换任务 ID。
@@ -228,28 +229,14 @@ export class ConvertServiceImpl implements ConvertService {
         }
 
         try {
-            await this.ffmpegService.extractSubtitles({
+            const extracted = await this.ffmpegService.extractSubtitles({
                 taskId,
                 inputFile,
                 outputFile: subtitleFile,
                 onProgress,
-                en: true,
             });
 
-            if (await this.hasNonEmptyFile(subtitleFile)) {
-                return true;
-            }
-
-            await this.fileSystemGateway.removeFileIfExists(subtitleFile);
-            await this.ffmpegService.extractSubtitles({
-                taskId,
-                inputFile,
-                outputFile: subtitleFile,
-                onProgress,
-                en: false,
-            });
-
-            if (await this.hasNonEmptyFile(subtitleFile)) {
+            if (extracted && await this.hasNonEmptyFile(subtitleFile)) {
                 return true;
             }
 

--- a/src/backend/services/FfmpegService.ts
+++ b/src/backend/services/FfmpegService.ts
@@ -80,19 +80,21 @@ export default interface FfmpegService {
         onProgress?: (progress: number) => void
     }): Promise<string>;
 
+    /**
+     * 提取文本字幕；英语学习场景优先英文字幕轨，无匹配时回退第一条文本字幕。
+     * @returns 成功提取时返回 true；源媒体没有可转 srt 的文本字幕时返回 false。
+     */
     extractSubtitles({
                          taskId,
                          inputFile,
                          outputFile,
-                         onProgress,
-                         en
+                         onProgress
                      }: {
         taskId: number,
         inputFile: string,
         outputFile?: string,
-        onProgress?: (progress: number) => void,
-        en: boolean
-    }): Promise<string>;
+        onProgress?: (progress: number) => void
+    }): Promise<boolean>;
 
     trimVideo(inputPath: string, startTime: number, endTime: number, outputPath: string, job?: string): Promise<void>;
 
@@ -326,7 +328,7 @@ export class FfmpegServiceImpl implements FfmpegService {
     }
 
     /**
-     * 提取字幕。
+     * 提取文本字幕；优先英文字幕轨，无匹配时由网关回退第一条文本字幕，返回是否提取到。
      */
     @WithSemaphore('ffmpeg')
     public async extractSubtitles({
@@ -334,25 +336,24 @@ export class FfmpegServiceImpl implements FfmpegService {
                                       inputFile,
                                       outputFile,
                                       onProgress,
-                                      en,
                                   }: {
         taskId: number,
         inputFile: string,
         outputFile?: string,
         onProgress?: (progress: number) => void,
-        en: boolean,
-    }): Promise<string> {
+    }): Promise<boolean> {
         const finalOutputFile = outputFile ?? inputFile.replace(path.extname(inputFile), '.srt');
-        const mapRule = en ? '0:s:m:language:eng?' : '0:s:0?';
         await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(inputFile);
         await this.storageDirectoryProvider.ensurePathAccessPermissionIfExists(finalOutputFile);
 
+        let extracted = false;
         await this.runCancelableTask(taskId, async (onCancelable) => {
-            await this.ffmpegGateway.extractSubtitles(
+            extracted = await this.ffmpegGateway.extractSubtitles(
                 {
                     inputFile,
                     outputFile: finalOutputFile,
-                    mapRule,
+                    // 英语学习场景优先英文字幕，无匹配时回退第一条文本字幕。
+                    preferLanguage: 'eng',
                 },
                 {
                     onProgress,
@@ -361,8 +362,7 @@ export class FfmpegServiceImpl implements FfmpegService {
                 },
             );
         });
-
-        return finalOutputFile;
+        return extracted;
     }
 
     /**
@@ -389,6 +389,8 @@ export class FfmpegServiceImpl implements FfmpegService {
             startSecond: startTime,
             endSecond: endTime,
             videoCodec: 'libx265',
+            // x265 默认 medium 预设极慢；短片段用 veryfast 提速明显且质量差异不可感知。
+            videoPreset: 'veryfast',
             audioCodec: 'aac',
             outputWidth: 640,
             crf: 28,

--- a/src/backend/services/gateways/media/FfmpegGateway.ts
+++ b/src/backend/services/gateways/media/FfmpegGateway.ts
@@ -112,18 +112,6 @@ export interface CreateThumbnailArgs {
 }
 
 /**
- * 分段音频参数。
- */
-export interface SplitAudioArgs {
-    /** 输入媒体文件路径。 */
-    inputFile: string;
-    /** 每段时长（秒）。 */
-    segmentSecond: number;
-    /** 输出路径模板。 */
-    outputPattern: string;
-}
-
-/**
  * 提取字幕参数。
  */
 export interface ExtractSubtitleArgs {
@@ -131,8 +119,20 @@ export interface ExtractSubtitleArgs {
     inputFile: string;
     /** 输出字幕文件路径。 */
     outputFile: string;
-    /** 字幕流映射规则。 */
-    mapRule: string;
+    /** 优先选择的字幕语言标签（如 eng）；无匹配时回退第一条文本字幕。 */
+    preferLanguage?: string;
+}
+
+/**
+ * 字幕提取命令参数：字幕流由网关 ffprobe 探测选定，调用方不得凭猜测拼 map 规则。
+ */
+export interface ExtractSubtitleCommandArgs {
+    /** 输入媒体文件路径。 */
+    inputFile: string;
+    /** 输出字幕文件路径。 */
+    outputFile: string;
+    /** 选定字幕流在输入媒体中的绝对流索引。 */
+    streamIndex: number;
 }
 
 /**
@@ -149,6 +149,8 @@ export interface TrimVideoArgs {
     endSecond: number;
     /** 视频编码器。 */
     videoCodec?: string;
+    /** 编码器速度预设（如 veryfast）；x265 默认 medium 过慢，按场景显式指定。 */
+    videoPreset?: string;
     /** 音频编码器。 */
     audioCodec?: string;
     /** 输出宽度。 */
@@ -218,17 +220,17 @@ export default interface FfmpegGateway {
     /** 生成缩略图。 */
     createThumbnail(args: CreateThumbnailArgs, options?: FfmpegRunOptions): Promise<void>;
 
-    /** 分割为音频片段。 */
-    splitAudio(args: SplitAudioArgs, options?: FfmpegRunOptions): Promise<void>;
-
     /** 转换为 MP4。 */
     toMp4(inputFile: string, outputFile: string, options?: FfmpegRunOptions): Promise<void>;
 
     /** MKV 转 MP4。 */
     mkvToMp4(inputFile: string, outputFile: string, options?: FfmpegRunOptions): Promise<void>;
 
-    /** 提取字幕。 */
-    extractSubtitles(args: ExtractSubtitleArgs, options?: FfmpegRunOptions): Promise<void>;
+    /**
+     * 提取文本字幕；优先匹配 preferLanguage 的文本字幕轨，无匹配时取第一条。
+     * 源媒体没有可转 srt 的文本字幕（如只有 PGS 图形字幕）时返回 false。
+     */
+    extractSubtitles(args: ExtractSubtitleArgs, options?: FfmpegRunOptions): Promise<boolean>;
 
     /** 裁剪视频。 */
     trimVideo(args: TrimVideoArgs, options?: FfmpegRunOptions): Promise<void>;


### PR DESCRIPTION
## 背景

代码审查发现 FFmpeg 命令构建器存在多处不符合最佳实践的参数拼法，其中两处会直接导致用户可见故障：

1. **奇数高度裁剪直接报错**：`scale=640:-1` 在原始宽高比算出奇数高度时，libx264/libx265 编码 yuv420p 会报 `height not divisible by 2`；
2. **10bit 源产出不可播放片段**：HEVC Main10 源经 trimVideo/toMp4 编码后保持 10bit（High10/Main10 profile），Chromium 普遍无法播放——收藏片段恰好要在应用内播放；
3. **字幕提取靠猜测式重试**：`0:s:m:language:eng?` 会映射所有英文字幕流，eng SRT + eng PGS 双流写单文件 srt 直接失败；纯图形字幕源两段重试均失败；
4. **x265 默认 medium 预设过慢**：短片段导出无感知质量收益却慢数倍。

## 改动

- `scale=-1` → `scale=-2`：高度自动取偶，杜绝编码报错
- trimVideo / toMp4 强制 `-pix_fmt yuv420p`，10bit 源不再产出浏览器放不了的输出；toMp4 补 `+faststart` 与 mkvToMp4 对齐
- trimVideo 支持并使用 `-preset veryfast`
- 字幕提取重构为 **ffprobe 探测选流**：文本字幕编码器白名单（subrip/ass/mov_text 等）筛掉 PGS/DVB 图形字幕，优先偏好语言、回退第一条，`-map 0:<index>` 只映射选定的单条流；无文本字幕返回 `false`，不再“跑失败→删文件→换轨道重试”
- ConvertService 两段式回退简化为单次调用
- 删除无调用方的 `splitAudio` 死代码及对应测试

## 验证

- [x] `yarn test:run` 全量通过（189 passed，含真实 ffmpeg 二进制的冒烟测试）
- [x] 新增用例：奇数高度取偶、偏好语言选流、纯图形字幕返回 false 且不启动 ffmpeg、无字幕媒体不产出文件
- 不涉及 `drizzle/` 迁移，无需重新执行 `yarn run download`