### PR TITLE
feat(storage): 设置页存储用量升级为分类环形图统计

### DIFF
--- a/src/backend/controllers/StorageController.ts
+++ b/src/backend/controllers/StorageController.ts
@@ -3,11 +3,18 @@ import Controller from '@/backend/controllers/Controller';
 import { inject, injectable } from 'inversify';
 import TYPES from '@/backend/ioc/types';
 import { StorageStatusVO } from '@/common/types/vo/StorageStatusVO';
+import {
+    StorageUsageItemVO,
+    StorageUsageVO,
+} from '@/common/contracts/storage-usage-vo';
 import StorageDirectoryProvider, {
     StorageDirectoryTarget,
 } from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import FileSystemGateway from '@/backend/services/gateways/storage/FileSystemGateway';
-import { getStorageRootStatus } from '@/backend/infrastructure/storage/StorageDirectorySupport';
+import {
+    getStorageRootStatus,
+    resolveStorageDirectory,
+} from '@/backend/infrastructure/storage/StorageDirectorySupport';
 import { SettingsStore } from '@/backend/services/gateways/SettingsStore';
 
 @injectable()
@@ -17,32 +24,55 @@ export default class StorageController implements Controller {
     @inject(TYPES.FileSystemGateway) private fileSystemGateway!: FileSystemGateway;
 
     /**
-     * 查询媒体库目录占用空间。
+     * 查询媒体库存储用量明细。
      *
      * 行为说明：
-     * - 仅在媒体库可访问时才执行目录遍历；
-     * - 目录失效时直接抛出显式错误，避免误报为 0 KB。
+     * - 仅在媒体库可访问时才执行目录遍历，目录失效时抛出显式错误；
+     * - 固定子目录（videos、models 等）尚未创建时按 0 统计，不视为异常；
+     * - 未纳入固定分类的文件统一归入 `other` 分类。
      */
-    public async queryCacheSize(): Promise<string> {
+    public async queryStorageUsage(): Promise<StorageUsageVO> {
         const libraryRoot = await this.storageDirectoryProvider.provideDirectory(StorageDirectoryTarget.LIBRARY_ROOT);
         const totalBytes = await this.fileSystemGateway.getDirectorySize(libraryRoot);
-        return this.formatBytes(totalBytes);
+
+        const videosBytes = await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.VIDEOS);
+        const favouriteClipsBytes = await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.FAVORITE_CLIPS);
+        const wordClipsBytes = await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.WORD_VIDEO);
+        const tempBytes = (await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.TEMP))
+            + (await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.TEMP_OSS));
+        const modelsBytes = await this.queryDirectoryUsage(libraryRoot, StorageDirectoryTarget.MODELS);
+
+        // word_video 位于 favorite_clips 内，收藏片段分类只保留其余部分；
+        // 目录内容在两次遍历之间可能变化，差值为负时按 0 展示。
+        const favouriteClipsOnlyBytes = Math.max(favouriteClipsBytes - wordClipsBytes, 0);
+        const otherBytes = Math.max(
+            totalBytes - videosBytes - favouriteClipsOnlyBytes - wordClipsBytes - tempBytes - modelsBytes,
+            0,
+        );
+
+        const knownItems: StorageUsageItemVO[] = [
+            { category: 'videos', bytes: videosBytes },
+            { category: 'favorite_clips', bytes: favouriteClipsOnlyBytes },
+            { category: 'word_clips', bytes: wordClipsBytes },
+            { category: 'models', bytes: modelsBytes },
+            { category: 'temp', bytes: tempBytes },
+            { category: 'other', bytes: otherBytes },
+        ];
+        const items = knownItems
+            .filter((item) => item.bytes > 0)
+            .sort((a, b) => b.bytes - a.bytes);
+
+        return { totalBytes, items };
     }
 
     /**
-     * 将字节数转换为设置页使用的可读大小。
-     * @param bytes 文件总大小，单位为字节。
-     * @returns 带单位的文件大小。
+     * 统计指定目标目录的占用大小；目录尚未创建时返回 0。
+     * @param libraryRoot 已确认可访问的媒体库根目录。
+     * @param target 目录目标。
+     * @returns 目录占用大小，单位字节。
      */
-    private formatBytes(bytes: number): string {
-        const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-        let size = bytes;
-        let unitIndex = 0;
-        while (size >= 1024 && unitIndex < units.length - 1) {
-            size /= 1024;
-            unitIndex += 1;
-        }
-        return `${size.toFixed(2)} ${units[unitIndex]}`;
+    private async queryDirectoryUsage(libraryRoot: string, target: StorageDirectoryTarget): Promise<number> {
+        return this.fileSystemGateway.getDirectorySizeIfExists(resolveStorageDirectory(libraryRoot, target));
     }
 
     /**
@@ -63,7 +93,7 @@ export default class StorageController implements Controller {
 
 
     registerRoutes(): void {
-        registerRoute('storage/cache/size', () => this.queryCacheSize());
+        registerRoute('storage/usage', () => this.queryStorageUsage());
         registerRoute('storage/status', () => this.queryStorageStatus());
         registerRoute('storage/collection/paths', () => this.listCollectionPaths());
     }

--- a/src/backend/infrastructure/storage/AccessRecoveringFileSystemGateway.ts
+++ b/src/backend/infrastructure/storage/AccessRecoveringFileSystemGateway.ts
@@ -100,6 +100,17 @@ export default class AccessRecoveringFileSystemGateway implements FileSystemGate
     }
 
     /**
+     * 计算目录内所有普通文件的总大小；目录不存在时返回 0。
+     *
+     * @param directoryPath 目录绝对路径。
+     * @returns 文件总大小，单位为字节；目录不存在时返回 0。
+     */
+    public async getDirectorySizeIfExists(directoryPath: string): Promise<number> {
+        await this.ensureAccessible(directoryPath);
+        return this.inner.getDirectorySizeIfExists(directoryPath);
+    }
+
+    /**
      * 复制普通文件。
      * @param sourcePath 源文件绝对路径。
      * @param targetPath 目标文件绝对路径；目标路径的目录需已存在。

--- a/src/backend/infrastructure/storage/FileSystemGatewayImpl.ts
+++ b/src/backend/infrastructure/storage/FileSystemGatewayImpl.ts
@@ -121,6 +121,23 @@ export default class FileSystemGatewayImpl implements FileSystemGateway {
     }
 
     /**
+     * 计算目录内所有普通文件的总大小；目录不存在时返回 0。
+     *
+     * @param directoryPath 目录绝对路径。
+     * @returns 文件总大小，单位为字节；目录不存在时返回 0。
+     */
+    public async getDirectorySizeIfExists(directoryPath: string): Promise<number> {
+        try {
+            return await this.getDirectorySize(directoryPath);
+        } catch (error) {
+            if (this.isMissingPathError(error)) {
+                return 0;
+            }
+            throw error;
+        }
+    }
+
+    /**
      * 写入 UTF-8 文本文件。
      * @param filePath 文件绝对路径。
      * @param content 待写入的文本内容。

--- a/src/backend/services/gateways/storage/FileSystemGateway.ts
+++ b/src/backend/services/gateways/storage/FileSystemGateway.ts
@@ -65,6 +65,17 @@ export default interface FileSystemGateway {
     copyFile(sourcePath: string, targetPath: string): Promise<void>;
 
     /**
+     * 计算目录内所有普通文件的总大小；目录不存在时返回 0。
+     *
+     * 适用于可选目录的统计场景（例如尚未下载的模型目录）；
+     * 目录存在但无法读取时仍然直接抛出错误。
+     *
+     * @param directoryPath 目录绝对路径。
+     * @returns 文件总大小，单位为字节；目录不存在时返回 0。
+     */
+    getDirectorySizeIfExists(directoryPath: string): Promise<number>;
+
+    /**
      * 写入 UTF-8 文本文件。
      * @param filePath 文件绝对路径。
      * @param content 待写入的文本内容。

--- a/src/common/api/api-def.ts
+++ b/src/common/api/api-def.ts
@@ -33,6 +33,7 @@ import { ShortcutSettingDetailVO, ShortcutSettingSaveVO } from '@/common/types/v
 import { ProxySettingDetailVO, ProxySettingSaveVO } from '@/common/contracts/proxy-setting-vo';
 import { AppearanceSettingVO } from '@/common/contracts/appearance-setting-vo';
 import { StorageSettingVO } from '@/common/contracts/storage-setting-vo';
+import { StorageUsageVO } from '@/common/contracts/storage-usage-vo';
 import {
     RuntimeSettingSaveRequest,
     RuntimeSettingsSnapshot,
@@ -219,7 +220,7 @@ interface SubtitleTimestampAdjustmentControllerDef {
 }
 
 interface StorageDef {
-    'storage/cache/size': { params: void, return: string };
+    'storage/usage': { params: void, return: StorageUsageVO };
     'storage/status': { params: void, return: StorageStatusVO };
     'storage/collection/paths': { params: void, return: string[] };
 }

--- a/src/common/contracts/storage-usage-vo.ts
+++ b/src/common/contracts/storage-usage-vo.ts
@@ -1,0 +1,37 @@
+/**
+ * 媒体库存储用量统计值对象。
+ *
+ * 按固定子目录分类统计媒体库占用，供设置页的存储用量图表展示。
+ */
+
+/**
+ * 存储用量分类键。
+ *
+ * - `videos` / `models` / `temp` 对应媒体库下的同名目录，其中 `temp` 合并 `temp` 与 `temp_oss`；
+ * - `word_clips` 对应 `favorite_clips/word_video`；
+ * - `favorite_clips` 仅统计 `favorite_clips` 下除 `word_video` 外的内容；
+ * - `other` 统计未纳入上述分类的其余文件。
+ */
+export type StorageUsageCategory =
+    | 'videos'
+    | 'favorite_clips'
+    | 'word_clips'
+    | 'models'
+    | 'temp'
+    | 'other';
+
+/** 单个分类的占用大小。 */
+export interface StorageUsageItemVO {
+    /** 分类键。 */
+    category: StorageUsageCategory;
+    /** 该分类下所有文件的总大小，单位字节。 */
+    bytes: number;
+}
+
+/** 媒体库存储用量统计结果。 */
+export interface StorageUsageVO {
+    /** 媒体库内全部文件的总大小，单位字节。 */
+    totalBytes: number;
+    /** 各分类占用明细，按大小降序排列；仅包含大小大于 0 的分类。 */
+    items: StorageUsageItemVO[];
+}

--- a/src/fronted/features/settings/StorageSetting.tsx
+++ b/src/fronted/features/settings/StorageSetting.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import SettingsPageShell from '@/fronted/features/settings/components/form/SettingsPageShell';
 import { SettingCard, SettingRow, SettingsLoadingSkeleton } from '@/fronted/features/settings/components/form';
+import StorageUsageCard from '@/fronted/features/settings/components/StorageUsageCard';
 import { Button } from '@/fronted/components/ui/button';
 import { FolderOpen, HardDrive, RefreshCw, Trash2, FolderSync } from 'lucide-react';
 import { swrApiMutate } from '@/fronted/lib/swr-util';
@@ -14,6 +15,7 @@ import { useAutoSaveSettingsForm } from '@/fronted/features/settings/useAutoSave
 import useSWR from 'swr';
 import { StorageStatusVO } from '@/common/types/vo/StorageStatusVO';
 import { StorageSettingVO } from '@/common/contracts/storage-setting-vo';
+import { StorageUsageVO } from '@/common/contracts/storage-usage-vo';
 
 type StorageFormValues = StorageSettingVO;
 
@@ -22,8 +24,10 @@ type StorageFormValues = StorageSettingVO;
  */
 const StorageSetting = () => {
     const { t } = useI18nTranslation('settings');
-    const [size, setSize] = React.useState<string>('--');
     const [storageStatus, setStorageStatus] = React.useState<StorageStatusVO | null>(null);
+    const [usage, setUsage] = React.useState<StorageUsageVO | null>(null);
+    // 初始即为待加载状态，避免首次查询完成前误显示“目录不可用”。
+    const [usageLoading, setUsageLoading] = React.useState(true);
 
     const { data: detail } = useSWR<StorageSettingVO>('settings/storage/detail', () =>
         settingsApi.getStorage(),
@@ -33,7 +37,7 @@ const StorageSetting = () => {
     const { control, formState, setValue } = form;
 
     /**
-     * 查询媒体库目录状态与占用空间。
+     * 查询媒体库目录状态与存储用量明细。
      */
     const loadStorageStatus = React.useCallback(async (configuredPath: string) => {
         try {
@@ -41,12 +45,16 @@ const StorageSetting = () => {
             setStorageStatus(nextStatus);
 
             if (!nextStatus.available) {
-                setSize('--');
+                setUsage(null);
                 return;
             }
 
-            const nextSize = await settingsApi.getCacheSize();
-            setSize(nextSize);
+            setUsageLoading(true);
+            try {
+                setUsage(await settingsApi.getStorageUsage());
+            } finally {
+                setUsageLoading(false);
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             setStorageStatus({
@@ -60,7 +68,7 @@ const StorageSetting = () => {
                 code: 'missing',
                 message,
             });
-            setSize('--');
+            setUsage(null);
         }
     }, []);
 
@@ -130,6 +138,16 @@ const StorageSetting = () => {
         await settingsApi.openCacheFolder();
     };
 
+    /**
+     * 手动刷新存储状态与用量明细。
+     */
+    const handleRefreshUsage = React.useCallback(() => {
+        if (!detail) {
+            return;
+        }
+        loadStorageStatus(detail.path).catch(() => undefined);
+    }, [detail, loadStorageStatus]);
+
     const libraryAvailable = storageStatus?.available ?? false;
     const canSyncCollections = libraryAvailable && !formState.isDirty && autoSaveStatus !== 'saving';
     const canOpenLibrary = libraryAvailable;
@@ -183,14 +201,6 @@ const StorageSetting = () => {
                 <SettingCard
                     title={t('storage.libraryPathTitle')}
                     icon={HardDrive}
-                    headerAction={
-                        <div className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-                            <span>{t('storage.occupiedSpace')}</span>
-                            <span className="font-mono font-semibold text-foreground px-2 py-0.5 rounded bg-muted/80">
-                                {size}
-                            </span>
-                        </div>
-                    }
                 >
                     <SettingRow
                         title={t('storage.libraryPathTitle')}
@@ -228,6 +238,13 @@ const StorageSetting = () => {
                         </div>
                     </SettingRow>
                 </SettingCard>
+
+                {/* 存储用量卡片 */}
+                <StorageUsageCard
+                    usage={usage}
+                    loading={usageLoading}
+                    onRefresh={handleRefreshUsage}
+                />
 
                 {/* 资源同步卡片 */}
                 <SettingCard

--- a/src/fronted/features/settings/components/StorageUsageCard.tsx
+++ b/src/fronted/features/settings/components/StorageUsageCard.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Cell, Pie, PieChart } from 'recharts';
+import { ChartPie, RefreshCw } from 'lucide-react';
+import { Button } from '@/fronted/components/ui/button';
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/fronted/components/ui/chart';
+import { cn } from '@/fronted/lib/utils';
+import { SettingCard } from '@/fronted/features/settings/components/form';
+import {
+    StorageUsageCategory,
+    StorageUsageVO,
+} from '@/common/contracts/storage-usage-vo';
+
+/**
+ * 各用量分类在图表中的固定配色；同时用于图例色块。
+ */
+const USAGE_CHART_COLORS: Record<StorageUsageCategory, string> = {
+    videos: '#3b82f6',
+    favorite_clips: '#f97316',
+    word_clips: '#10b981',
+    models: '#8b5cf6',
+    temp: '#64748b',
+    other: '#ec4899',
+};
+
+/**
+ * 将字节数格式化为带单位的可读大小。
+ * @param bytes 文件大小，单位字节。
+ * @returns 带单位的文件大小；不足 1 KB 时保留整数。
+ */
+function formatBytes(bytes: number): string {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let size = bytes;
+    let unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex += 1;
+    }
+    return unitIndex === 0
+        ? `${size} ${units[unitIndex]}`
+        : `${size.toFixed(2)} ${units[unitIndex]}`;
+}
+
+export interface StorageUsageCardProps {
+    /** 用量明细；`null` 表示尚未加载完成或存储目录不可用。 */
+    usage: StorageUsageVO | null;
+    /** 是否正在加载用量明细。 */
+    loading: boolean;
+    /** 手动触发一次用量刷新。 */
+    onRefresh: () => void;
+}
+
+/**
+ * 存储用量卡片：以环形图加明细列表展示媒体库各分类的占用大小。
+ */
+const StorageUsageCard = ({ usage, loading, onRefresh }: StorageUsageCardProps) => {
+    const { t } = useTranslation('settings');
+
+    const chartConfig = React.useMemo<ChartConfig>(() => {
+        const config: ChartConfig = {};
+        for (const category of Object.keys(USAGE_CHART_COLORS) as StorageUsageCategory[]) {
+            config[category] = {
+                label: t(`storage.usage.categories.${category}`),
+                color: USAGE_CHART_COLORS[category],
+            };
+        }
+        return config;
+    }, [t]);
+
+    const chartData = React.useMemo(
+        () => (usage?.items ?? []).map((item) => ({
+            category: item.category,
+            bytes: item.bytes,
+            fill: `var(--color-${item.category})`,
+        })),
+        [usage],
+    );
+
+    const totalBytes = usage?.totalBytes ?? 0;
+
+    /**
+     * 状态文案：加载中、目录不可用或媒体库为空时替代图表展示。
+     */
+    const statusMessage = loading
+        ? t('storage.usage.loading')
+        : usage === null
+            ? t('storage.usage.unavailable')
+            : totalBytes === 0
+                ? t('storage.usage.empty')
+                : null;
+
+    return (
+        <SettingCard
+            title={t('storage.usage.title')}
+            icon={ChartPie}
+            headerAction={(
+                <div className="flex items-center gap-2">
+                    <div className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+                        <span>{t('storage.usage.totalLabel')}</span>
+                        <span className="font-mono font-semibold text-foreground px-2 py-0.5 rounded bg-muted/80">
+                            {usage ? formatBytes(totalBytes) : '--'}
+                        </span>
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-7 w-7"
+                        type="button"
+                        onClick={onRefresh}
+                        disabled={loading}
+                    >
+                        <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+                    </Button>
+                </div>
+            )}
+        >
+            {statusMessage ? (
+                <div className="flex h-44 items-center justify-center p-4 text-sm text-muted-foreground">
+                    {statusMessage}
+                </div>
+            ) : (
+                <div className="flex flex-col items-center gap-6 p-4 sm:flex-row sm:gap-8">
+                    <ChartContainer
+                        config={chartConfig}
+                        className="mx-auto aspect-square h-44 w-44 shrink-0"
+                    >
+                        <PieChart>
+                            <ChartTooltip
+                                cursor={false}
+                                content={(
+                                    <ChartTooltipContent
+                                        hideLabel
+                                        formatter={(value, name) => (
+                                            <div className="flex min-w-32 items-center justify-between gap-4 leading-none">
+                                                <span className="text-muted-foreground">
+                                                    {chartConfig[name as string]?.label ?? name}
+                                                </span>
+                                                <span className="font-mono font-medium tabular-nums text-foreground">
+                                                    {formatBytes(Number(value))}
+                                                    {totalBytes > 0 && (
+                                                        <span className="ml-2 text-muted-foreground">
+                                                            {((Number(value) / totalBytes) * 100).toFixed(1)}%
+                                                        </span>
+                                                    )}
+                                                </span>
+                                            </div>
+                                        )}
+                                    />
+                                )}
+                            />
+                            <Pie
+                                data={chartData}
+                                dataKey="bytes"
+                                nameKey="category"
+                                innerRadius={50}
+                                outerRadius={78}
+                                paddingAngle={2}
+                                strokeWidth={2}
+                            >
+                                {chartData.map((entry) => (
+                                    <Cell key={entry.category} fill={entry.fill} />
+                                ))}
+                            </Pie>
+                        </PieChart>
+                    </ChartContainer>
+                    <div className="w-full min-w-0 flex-1 space-y-2">
+                        {(usage?.items ?? []).map((item) => (
+                            <div
+                                key={item.category}
+                                className="flex items-center gap-2 text-xs"
+                            >
+                                <span
+                                    className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                                    style={{ backgroundColor: USAGE_CHART_COLORS[item.category] }}
+                                />
+                                <span className="text-muted-foreground truncate">
+                                    {t(`storage.usage.categories.${item.category}`)}
+                                </span>
+                                <span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+                                    {formatBytes(item.bytes)}
+                                </span>
+                                <span className="w-14 shrink-0 text-right font-mono tabular-nums text-muted-foreground">
+                                    {((item.bytes / totalBytes) * 100).toFixed(1)}%
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </SettingCard>
+    );
+};
+
+export default StorageUsageCard;

--- a/src/fronted/features/settings/settingsApi.ts
+++ b/src/fronted/features/settings/settingsApi.ts
@@ -204,11 +204,11 @@ export const settingsApi = {
     getStorageStatus: () => backendClient.call('storage/status'),
 
     /**
-     * 查询缓存大小。
+     * 查询存储用量明细。
      *
-     * @returns 缓存大小。
+     * @returns 媒体库各分类占用大小与总大小。
      */
-    getCacheSize: () => backendClient.call('storage/cache/size'),
+    getStorageUsage: () => backendClient.call('storage/usage'),
 
     /**
      * 保存存储设置。

--- a/src/fronted/i18n/locales/en-US/settings.json
+++ b/src/fronted/i18n/locales/en-US/settings.json
@@ -181,7 +181,6 @@
         "descriptionLine2": "Cache is managed automatically. Manual modifications are not recommended.",
         "resetDatabase": "Reset Database",
         "openLibraryFolder": "Open Library Folder",
-        "occupiedSpace": "Storage Used",
         "libraryPathTitle": "Storage Path (Library Path)",
         "libraryPathDescription": "Restart DashPlayer for storage path changes to take effect.",
         "switchCollection": "Saved Clips Folder",
@@ -205,7 +204,22 @@
             "tooltipTitle": "Resync Vocabulary Studio",
             "tooltipDescription": "Rebuild Vocabulary Studio clip records from the word_video folder when data is missing or corrupted."
         },
-        "wordClipsHint": "Vocabulary Studio clips are stored under word_video. Use this action to rebuild database records if needed."
+        "wordClipsHint": "Vocabulary Studio clips are stored under word_video. Use this action to rebuild database records if needed.",
+        "usage": {
+            "title": "Storage Usage",
+            "totalLabel": "Total Used",
+            "loading": "Measuring storage usage...",
+            "unavailable": "Storage directory unavailable. Usage cannot be measured.",
+            "empty": "No files are using storage space yet.",
+            "categories": {
+                "videos": "Videos",
+                "favorite_clips": "Saved Clips",
+                "word_clips": "Vocabulary Studio Clips",
+                "models": "Local Models",
+                "temp": "Temporary Files",
+                "other": "Other Files"
+            }
+        }
     },
     "engineSelection": {
         "title": "Feature Controls",

--- a/src/fronted/i18n/locales/zh-CN/settings.json
+++ b/src/fronted/i18n/locales/zh-CN/settings.json
@@ -181,7 +181,6 @@
         "descriptionLine2": "缓存数据由系统自动管理，无需手动修改。",
         "resetDatabase": "重置数据库",
         "openLibraryFolder": "打开 Library 文件夹",
-        "occupiedSpace": "占用空间",
         "libraryPathTitle": "存储路径（Library Path）",
         "libraryPathDescription": "更改存储路径后需重启 DashPlayer 生效。",
         "switchCollection": "收藏片段文件夹",
@@ -205,7 +204,22 @@
             "tooltipTitle": "重新同步词汇工坊",
             "tooltipDescription": "当数据丢失或异常时，可从 word_video 文件夹重新构建词汇工坊片段记录。"
         },
-        "wordClipsHint": "词汇工坊片段存储在 word_video 目录，需要时可在此重建数据库记录。"
+        "wordClipsHint": "词汇工坊片段存储在 word_video 目录，需要时可在此重建数据库记录。",
+        "usage": {
+            "title": "存储用量",
+            "totalLabel": "总占用",
+            "loading": "正在统计存储用量...",
+            "unavailable": "存储目录不可用，暂无法统计用量",
+            "empty": "媒体库当前没有占用空间的文件",
+            "categories": {
+                "videos": "视频文件",
+                "favorite_clips": "收藏片段",
+                "word_clips": "词汇工坊片段",
+                "models": "本地模型",
+                "temp": "临时文件",
+                "other": "其他文件"
+            }
+        }
     },
     "engineSelection": {
         "title": "功能设置",

--- a/src/test/memory-file-system-gateway.ts
+++ b/src/test/memory-file-system-gateway.ts
@@ -111,6 +111,18 @@ export class MemoryFileSystemGateway implements FileSystemGateway {
     }
 
     /**
+     * 计算目录内所有普通文件的总大小；目录不存在时返回 0。
+     *
+     * 内存实现没有不可读目录的形态，直接复用目录遍历结果。
+     *
+     * @param directoryPath 目录绝对路径。
+     * @returns 文件总大小，单位为字节；目录不存在时返回 0。
+     */
+    public async getDirectorySizeIfExists(directoryPath: string): Promise<number> {
+        return this.getDirectorySize(directoryPath);
+    }
+
+    /**
      * 复制普通文件。
      * @param sourcePath 源文件绝对路径。
      * @param targetPath 目标文件绝对路径。


### PR DESCRIPTION
## 背景

设置 → 存储页原来只在路径卡片标题旁显示一个“占用空间”总数，信息量太少。本次重做为独立的存储用量卡片，并复用项目 UI 库中已有的 shadcn chart（recharts）图表组件。

## 改动

- **后端**
  - 新增 `storage/usage` IPC：按目录分类统计媒体库占用——视频（`videos`）、收藏片段（`favorite_clips`，扣除 `word_video`）、词汇工坊片段（`favorite_clips/word_video`）、本地模型（`models`）、临时文件（`temp` + `temp_oss`）、其他；替换只返回总大小的 `storage/cache/size`
  - `FileSystemGateway` 新增 `getDirectorySizeIfExists`：可选子目录尚未创建时按 0 统计，目录存在但不可读仍抛错
- **前端**
  - 新增 `StorageUsageCard`：recharts 环形图展示分类占比（悬停显示大小与百分比），右侧明细列表；卡片头部显示总占用并支持手动刷新
  - 加载中 / 存储目录不可用 / 媒体库为空三种状态均有明确文案，无兜底静默
  - 同步更新中英文 i18n 文案

## 验证

- `npx tsc --noEmit`：改动文件无错误（`src/preload.ts` 的 `SimpleEvent` 缺 import 为 main 上已有问题，与本次无关）
- `npx eslint` 改动文件全部通过
- `proxy-setting.test.tsx` 通过
- UI：环形图 / 明细列表 / 刷新按钮 / 三种空态文案本地验证通过

不涉及 `drizzle/` 迁移，无需重新执行 `yarn run download`。