### PR TITLE
ci: release-please-action 升级到 v5（runtime 切换到 Node 24）

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## 背景

GitHub Actions 提示 Node 20 已弃用：

> The following actions target Node.js 20 but are being forced to run on Node.js 24: googleapis/release-please-action@v4

当前使用的 `release-please-action@v4`（v4.4.1）内部仍基于 Node 20 打包。上游已于 2026-04-22 发布 [v5.0.0](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0)，唯一的 breaking change 就是 runtime 升级到 Node 24，同时 release-please 从 17.3.0 升至 17.6.0，对现有 `release-please-config.json` / manifest 用法无影响。

## 改动

- `.github/workflows/release-please.yml`：`googleapis/release-please-action@v4` → `@v5`

## 验证

- 合并后观察下一次 Release Please 运行，确认不再出现 Node 20 弃用警告，发版 PR 正常产出。