### PR TITLE
fix: 钉住 tencentcloud-sdk-nodejs 到 4.0.x，修复腾讯翻译运行时崩溃

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tar-fs": "^3.1.3",
-    "tencentcloud-sdk-nodejs": "^4.0.764",
+    "tencentcloud-sdk-nodejs": "~4.0.1054",
     "tokenlens": "^1.3.1",
     "ts-error": "^1.0.6",
     "unbzip2-stream": "^1.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8532,7 +8532,7 @@ form-data-encoder@1.7.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
   integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
 
-form-data@^3.0.4:
+form-data@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.5.tgz#2ea3ec24f0dcb7e0262a11efb732031240ea8e9f"
   integrity sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==
@@ -9478,7 +9478,7 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@2.0.0, ini@^2.0.0:
+ini@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
@@ -14224,20 +14224,19 @@ temp@^0.9.0:
     mkdirp "^0.5.1"
     rimraf "~2.6.2"
 
-tencentcloud-sdk-nodejs@^4.0.764:
-  version "4.1.306"
-  resolved "https://registry.yarnpkg.com/tencentcloud-sdk-nodejs/-/tencentcloud-sdk-nodejs-4.1.306.tgz#9d880ad9b5bd94860b4c51ce689d8e89e638098c"
-  integrity sha512-/sjQbZiXcxr+lsfVcCA9DTiIjk1qAmZ8TUOW+S/cK/EkakErPIwummwzg7BLjoIRo6jg0mmpiLi4u2ogybpVXQ==
+tencentcloud-sdk-nodejs@~4.0.1054:
+  version "4.0.1054"
+  resolved "https://registry.yarnpkg.com/tencentcloud-sdk-nodejs/-/tencentcloud-sdk-nodejs-4.0.1054.tgz#588fe62ed186b91326c67717d819dbf40a1f4441"
+  integrity sha512-+QR+ullUW2iZhSTkkBBF1cJxTrUfKgJ7KB8InwPRe/EsSjmOQdUweP4gRplFDMhFBzoaotpaWPShmmirG0nPiw==
   dependencies:
-    form-data "^3.0.4"
+    form-data "^3.0.0"
     get-stream "^6.0.0"
     https-proxy-agent "^5.0.0"
-    ini "^2.0.0"
     is-stream "^2.0.0"
     json-bigint "^1.0.0"
     node-fetch "^2.2.0"
     tslib "1.13.0"
-    uuid "^11.1.1"
+    uuid "^9.0.1"
 
 terser-webpack-plugin@^5.3.11:
   version "5.3.16"
@@ -14853,10 +14852,10 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.2.tgz#d5ae03e4db0881c87271f8b0b9bd7312d02c799a"
   integrity sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==
 
-uuid@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
-  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## 背景

PR #218（依赖第一档升级）中 `tencentcloud-sdk-nodejs` 声明范围 `^4.0.764` 浮动到了 4.1.306。腾讯在 4.1.x 中移除了 tmt/v20180321 客户端的 `TextTranslateBatch` 方法与 `TextTranslateBatchResponse` 类型（官方分包 `tencentcloud-sdk-nodejs-tmt@4.1.265` 同样没有），导致 `TencentClient.batchTrans` 运行时直接抛 `TypeError`，**腾讯翻译功能当前在 main 上不可用**。

主仓库 node_modules 为旧版时 tsc/测试均无法暴露此问题，fresh install 后 `tsc` 报 TS2339 才被发现。

## 修复方案

钉在 4.0.x 最终版 `~4.0.1054`：收 4.0.x 补丁、挡住 4.1.x。未选择迁移到 4.1.x 的新替代接口，因为那需要接口调研与真实凭据联调，属于独立功能工程。

## 验证步骤

- [x] fresh install 后 `tsc --noEmit`：TS2339 消除（仅剩 main 已知的 preload.ts SimpleEvent 存量错误）
- [x] 运行时验证：4.1.306 的 Client 原型仅 `ImageTranslateLLM`；4.0.1054 恢复 `TextTranslateBatch` 等 6 个方法
- [x] `yarn test:run` 全绿（209 passed，electron-rebuild 后）

## 注意

- `fix:` 类型会触发 Release Please 出 patch 版本
- 建议先于 electron-upgrade PR 合并