### PR TITLE
feat: 词汇工坊支持删除学习片段

### DIFF
--- a/src/backend/infrastructure/db/repositories/VideoLearningClipRepositoryImpl.ts
+++ b/src/backend/infrastructure/db/repositories/VideoLearningClipRepositoryImpl.ts
@@ -95,8 +95,19 @@ export default class VideoLearningClipRepositoryImpl implements VideoLearningCli
         });
     }
 
-    public async deleteByKey(key: string): Promise<void> {
-        await db.delete(videoLearningClip).where(eq(videoLearningClip.key, key));
+    /**
+     * 原子地删除一个片段及其全部单词关联。
+     *
+     * 行为说明：
+     * - 片段记录与其单词关联在一个事务内删除，避免留下孤儿关联导致统计虚高。
+     *
+     * @param key 片段键。
+     */
+    public async deleteClipWithWords(key: string): Promise<void> {
+        db.transaction((tx) => {
+            tx.delete(videoLearningClipWord).where(eq(videoLearningClipWord.clip_key, key)).run();
+            tx.delete(videoLearningClip).where(eq(videoLearningClip.key, key)).run();
+        });
     }
 
     /**

--- a/src/backend/services/VideoLearningService.ts
+++ b/src/backend/services/VideoLearningService.ts
@@ -442,12 +442,12 @@ export class VideoLearningServiceImpl implements VideoLearningService {
     }
 
     /**
-     * 删除片段的本地索引和远端文件。
+     * 删除片段的本地索引（含单词关联）和远端文件。
      *
      * @param key 片段键。
      */
     public async deleteLearningClip(key: string): Promise<void> {
-        await this.videoLearningClipRepository.deleteByKey(key);
+        await this.videoLearningClipRepository.deleteClipWithWords(key);
         await this.videoLearningOssService.delete(key);
     }
 

--- a/src/backend/services/repositories/VideoLearningClipRepository.ts
+++ b/src/backend/services/repositories/VideoLearningClipRepository.ts
@@ -17,6 +17,11 @@ export default interface VideoLearningClipRepository {
     listPage(query: VideoLearningClipPageQuery): Promise<VideoLearningClip[]>;
     exists(key: string): Promise<boolean>;
     saveClipWithWords(clip: InsertVideoLearningClip, words: InsertVideoLearningClipWord[]): Promise<void>;
-    deleteByKey(key: string): Promise<void>;
+    /**
+     * 原子地删除一个片段及其全部单词关联。
+     *
+     * @param key 片段键。
+     */
+    deleteClipWithWords(key: string): Promise<void>;
     replaceAll(clips: InsertVideoLearningClip[], words: InsertVideoLearningClipWord[]): Promise<void>;
 }

--- a/src/fronted/components/shared/common/ConfirmDeleteButton.tsx
+++ b/src/fronted/components/shared/common/ConfirmDeleteButton.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+import { cn } from '@/fronted/lib/utils';
+
+/** 待确认态自动复位等待时间（毫秒）。 */
+const CONFIRM_RESET_MS = 3000;
+
+type Props = {
+  /** 常态触发器的提示文案（兼作待确认态 tooltip）。 */
+  title: string;
+  /** 进入待确认态后按钮上显示的确认文案。 */
+  confirmLabel: string;
+  /** 删除请求是否进行中。 */
+  deleting: boolean;
+  /** 第二次点击确认后触发。 */
+  onConfirm: () => void;
+  /** 常态触发器的自定义样式；用于适配列表行、图片覆盖层等不同宿主。 */
+  triggerClassName?: string;
+};
+
+/**
+ * 原地两次点击确认的删除按钮。
+ *
+ * 行为说明：
+ * - 首次点击进入待确认态并变红显示确认文案；
+ * - 超时未再次点击会自动复位；
+ * - 再次点击才真正触发删除；
+ * - 删除进行中显示转圈并禁止重复提交。
+ */
+export default function ConfirmDeleteButton({ title, confirmLabel, deleting, onConfirm, triggerClassName }: Props) {
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const timer = window.setTimeout(() => setArmed(false), CONFIRM_RESET_MS);
+    return () => window.clearTimeout(timer);
+  }, [armed]);
+
+  const handleClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (deleting) return;
+    if (!armed) {
+      setArmed(true);
+      return;
+    }
+    setArmed(false);
+    onConfirm();
+  };
+
+  if (armed || deleting) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={deleting}
+        className={cn(
+          'px-1.5 py-0.5 rounded-md text-[10px] leading-none font-medium shrink-0 transition-colors cursor-pointer',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          deleting && 'opacity-60 cursor-not-allowed'
+        )}
+        title={title}
+      >
+        {deleting ? <Loader2 className="w-3 h-3 animate-spin" /> : confirmLabel}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        'p-1 rounded-md transition-all cursor-pointer shrink-0',
+        'text-muted-foreground hover:text-destructive hover:bg-destructive/10',
+        triggerClassName
+      )}
+      title={title}
+    >
+      <Trash2 className="w-3.5 h-3.5" />
+    </button>
+  );
+}

--- a/src/fronted/features/video-learning/VideoLearningPage.tsx
+++ b/src/fronted/features/video-learning/VideoLearningPage.tsx
@@ -457,10 +457,12 @@ export default function VideoLearningPage() {
    *
    * 行为说明：
    * - 后端同步删除数据库记录（含单词关联）与本地片段文件；
-   * - 删除后刷新片段列表与左侧词汇统计；
-   * - 删除的是当前播放片段则清空选中态（初始化效应会自动选中首条），
-   *   删除的是其前面的片段则平移下标保持播放对象不变；
-   * - 当前页被删空且不再存在时回退页码。
+   * - 删除成功后用 SWR 乐观更新在同一渲染批次内移除列表项并修正播放下标，
+   *   避免陈旧列表期间重新选中已删片段、触发对已删文件的缩略图/播放加载；
+   * - 下标指向被删片段时清空选中（初始化效应会自动选中首条），
+   *   其后的片段整体前移一位保持播放对象不变；
+   * - 当前页被删空且不再存在时回退页码；
+   * - 最后刷新左侧词汇统计。
    *
    * @param index 被删除片段在当前页列表中的下标。
    */
@@ -475,25 +477,31 @@ export default function VideoLearningPage() {
         return;
       }
 
-      // 清理被删片段的缩略图缓存，避免残留失效图片
-      setThumbnailUrls((prev) => {
-        if (!(clip.key in prev)) return prev;
-        const next = { ...prev };
-        delete next[clip.key];
-        return next;
+      setCurrentClipIndex((prev) => {
+        if (prev === index) return -1;
+        if (prev > index) return prev - 1;
+        return prev;
       });
-
-      // 修正播放选中态：删的是当前片段则清空，删的是前面的片段则平移下标
       if (currentClipIndex === index) {
-        setCurrentClipIndex(-1);
         setCurrentLineIndex(-1);
-      } else if (currentClipIndex > index) {
-        setCurrentClipIndex((prev) => prev - 1);
       }
 
-      const newData = await mutate(searchKey);
-      const newTotal = newData?.success ? newData.data.total : 0;
-      const newTotalPages = Math.max(1, Math.ceil(newTotal / PAGE_SIZE));
+      // 乐观移除被删片段并触发重校验；列表项与下标修正落在同一渲染批次，
+      // 避免陈旧列表期间重新选中已删片段、触发对已删文件的缩略图/播放加载。
+      // 删除已在后端成功，重校验失败时不回滚已删片段。
+      await mutate(searchKey, (current: typeof learningClips | undefined) => {
+        if (!current) return undefined;
+        return {
+          ...current,
+          data: {
+            ...current.data,
+            items: current.data.items.filter((item) => item.key !== clip.key),
+            total: Math.max(0, current.data.total - 1)
+          }
+        };
+      }, { revalidate: true, rollbackOnError: false });
+
+      const newTotalPages = Math.max(1, Math.ceil(Math.max(0, totalClips - 1) / PAGE_SIZE));
       if (page > newTotalPages) {
         setPage(newTotalPages);
       }
@@ -504,7 +512,7 @@ export default function VideoLearningPage() {
     } finally {
       setDeletingClipKey(null);
     }
-  }, [clips, currentClipIndex, deletingClipKey, fetchWords, mutate, page, searchKey, t]);
+  }, [clips, currentClipIndex, deletingClipKey, fetchWords, mutate, page, searchKey, t, totalClips]);
 
   return (
     <div className="w-full h-full flex flex-col overflow-hidden select-none bg-background text-foreground">

--- a/src/fronted/features/video-learning/VideoLearningPage.tsx
+++ b/src/fronted/features/video-learning/VideoLearningPage.tsx
@@ -55,6 +55,8 @@ export default function VideoLearningPage() {
   const [pendingClip, setPendingClip] = useState<PendingClipRequest | null>(null);
   const [thumbnailUrls, setThumbnailUrls] = useState<Record<string, string>>({});
   const [forcePlayKey, setForcePlayKey] = useState(0); // 用于强制播放器重新播放
+  // 正在删除的片段键，用于删除按钮转圈与防重复提交
+  const [deletingClipKey, setDeletingClipKey] = useState<string | null>(null);
   const inFlightThumbsRef = useRef<Set<string>>(new Set());
   const { mutate } = useSWRConfig();
 
@@ -450,6 +452,60 @@ export default function VideoLearningPage() {
     await mutate(searchKey);
   }, [fetchWords, mutate, searchKey]);
 
+  /**
+   * 删除片段并修正页面状态。
+   *
+   * 行为说明：
+   * - 后端同步删除数据库记录（含单词关联）与本地片段文件；
+   * - 删除后刷新片段列表与左侧词汇统计；
+   * - 删除的是当前播放片段则清空选中态（初始化效应会自动选中首条），
+   *   删除的是其前面的片段则平移下标保持播放对象不变；
+   * - 当前页被删空且不再存在时回退页码。
+   *
+   * @param index 被删除片段在当前页列表中的下标。
+   */
+  const handleClipDeleted = useCallback(async (index: number) => {
+    const clip = clips[index];
+    if (!clip || deletingClipKey) return;
+    setDeletingClipKey(clip.key);
+    try {
+      const result = await videoLearningApi.deleteClip(clip.key);
+      if (!result?.success) {
+        toast.error(t('vocabularyStudio.clipDeleteFailed'));
+        return;
+      }
+
+      // 清理被删片段的缩略图缓存，避免残留失效图片
+      setThumbnailUrls((prev) => {
+        if (!(clip.key in prev)) return prev;
+        const next = { ...prev };
+        delete next[clip.key];
+        return next;
+      });
+
+      // 修正播放选中态：删的是当前片段则清空，删的是前面的片段则平移下标
+      if (currentClipIndex === index) {
+        setCurrentClipIndex(-1);
+        setCurrentLineIndex(-1);
+      } else if (currentClipIndex > index) {
+        setCurrentClipIndex((prev) => prev - 1);
+      }
+
+      const newData = await mutate(searchKey);
+      const newTotal = newData?.success ? newData.data.total : 0;
+      const newTotalPages = Math.max(1, Math.ceil(newTotal / PAGE_SIZE));
+      if (page > newTotalPages) {
+        setPage(newTotalPages);
+      }
+      await fetchWords();
+    } catch (error) {
+      logger.error('删除片段失败', { error });
+      toast.error(t('vocabularyStudio.clipDeleteFailed'));
+    } finally {
+      setDeletingClipKey(null);
+    }
+  }, [clips, currentClipIndex, deletingClipKey, fetchWords, mutate, page, searchKey, t]);
+
   return (
     <div className="w-full h-full flex flex-col overflow-hidden select-none bg-background text-foreground">
       {/* 顶栏标题区：统一排版 */}
@@ -620,6 +676,8 @@ export default function VideoLearningPage() {
                   onClickClip={(idx) => {
                     playClip(idx);
                   }}
+                  deletingKey={deletingClipKey}
+                  onDeleteClip={handleClipDeleted}
                 />
               )}
             </div>

--- a/src/fronted/features/video-learning/components/ClipGrid.tsx
+++ b/src/fronted/features/video-learning/components/ClipGrid.tsx
@@ -6,19 +6,26 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@/fronted/components/ui/tooltip';
+import ConfirmDeleteButton from '@/fronted/components/shared/common/ConfirmDeleteButton';
 import { VideoClip } from '../types';
 import UrlUtil from '@/common/utils/UrlUtil';
 import TimeUtil from '@/common/utils/TimeUtil';
 import { cn } from '@/fronted/lib/utils';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   clips: VideoClip[];
   playingKey?: string;
   thumbnails?: Record<string, string>;
   onClickClip: (index: number) => void;
+  /** 正在删除的片段键，用于按钮转圈与防重复提交。 */
+  deletingKey?: string | null;
+  /** 请求删除某个片段，删除逻辑与状态刷新由页面负责。 */
+  onDeleteClip: (index: number) => void;
 };
 
-export default function ClipGrid({ clips, playingKey, thumbnails, onClickClip }: Props) {
+export default function ClipGrid({ clips, playingKey, thumbnails, onClickClip, deletingKey, onDeleteClip }: Props) {
+  const { t } = useTranslation('common');
   const getThumbnailUrlSync = (clip: VideoClip): string => {
     const raw = thumbnails?.[clip.key];
     if (!raw) return '';
@@ -112,8 +119,17 @@ export default function ClipGrid({ clips, playingKey, thumbnails, onClickClip }:
                       </div>
                     )}
 
-                    {/* hover提示 */}
-                    <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    {/* hover 操作区：删除（仅已完成片段）与详情提示 */}
+                    <div className="absolute top-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      {clip.sourceType !== 'local' && (
+                        <ConfirmDeleteButton
+                          title={t('deleteClip')}
+                          confirmLabel={t('confirmDelete')}
+                          deleting={deletingKey === clip.key}
+                          onConfirm={() => onDeleteClip(idx)}
+                          triggerClassName="bg-black/40 backdrop-blur-xs text-white/80 hover:bg-black/60 hover:text-white"
+                        />
+                      )}
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger asChild>

--- a/src/fronted/features/video-learning/components/WordSidebar.tsx
+++ b/src/fronted/features/video-learning/components/WordSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { Input } from '@/fronted/components/ui/input';
 import { Button } from '@/fronted/components/ui/button';
 import {
@@ -8,10 +8,11 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/fronted/components/ui/select';
-import { Search, Upload, Download, List, LocateFixed, Pencil, Trash2, Loader2, ArrowUpDown } from 'lucide-react';
+import { Search, Upload, Download, List, LocateFixed, Pencil, ArrowUpDown } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { cn } from '@/fronted/lib/utils';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+import ConfirmDeleteButton from '@/fronted/components/shared/common/ConfirmDeleteButton';
 import {
   Tooltip,
   TooltipContent,
@@ -35,81 +36,6 @@ export interface WordItem {
 
 /** 单词列表排序方式。 */
 type SortMode = 'usage' | 'alphabetical' | 'recentVideo';
-
-/** 删除确认态自动复位等待时间（毫秒）。 */
-const DELETE_CONFIRM_RESET_MS = 3000;
-
-interface WordDeleteButtonProps {
-  /** 所在行是否处于选中态，用于配色适配。 */
-  active: boolean;
-  /** 删除请求是否进行中。 */
-  deleting: boolean;
-  /** 第二次点击确认后触发。 */
-  onConfirm: () => void;
-}
-
-/**
- * 原地两次点击确认的删除按钮。
- *
- * 行为说明：
- * - 首次点击进入待确认态并变红显示确认文案；
- * - 超时未再次点击会自动复位；
- * - 再次点击才真正触发删除。
- */
-function WordDeleteButton({ active, deleting, onConfirm }: WordDeleteButtonProps) {
-  const { t } = useTranslation('common');
-  const [armed, setArmed] = useState(false);
-
-  useEffect(() => {
-    if (!armed) return;
-    const timer = window.setTimeout(() => setArmed(false), DELETE_CONFIRM_RESET_MS);
-    return () => window.clearTimeout(timer);
-  }, [armed]);
-
-  const handleClick = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    if (deleting) return;
-    if (!armed) {
-      setArmed(true);
-      return;
-    }
-    setArmed(false);
-    onConfirm();
-  };
-
-  if (armed || deleting) {
-    return (
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={deleting}
-        className={cn(
-          'px-1.5 py-0.5 rounded-md text-[10px] leading-none font-medium shrink-0 transition-colors cursor-pointer',
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-          deleting && 'opacity-60 cursor-not-allowed'
-        )}
-        title={t('deleteWord')}
-      >
-        {deleting ? <Loader2 className="w-3 h-3 animate-spin" /> : t('confirmDelete')}
-      </button>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className={cn(
-        'p-1 rounded-md transition-all cursor-pointer shrink-0',
-        'text-muted-foreground hover:text-destructive hover:bg-destructive/10',
-        active ? 'text-primary-foreground/70 hover:text-primary-foreground' : 'opacity-0 group-hover:opacity-100'
-      )}
-      title={t('deleteWord')}
-    >
-      <Trash2 className="w-3.5 h-3.5" />
-    </button>
-  );
-}
 
 type Props = {
   words: WordItem[];
@@ -375,10 +301,16 @@ export default function WordSidebar({
                       >
                         <Pencil className="w-3.5 h-3.5" />
                       </button>
-                      <WordDeleteButton
-                        active={active}
+                      <ConfirmDeleteButton
+                        title={t('deleteWord')}
+                        confirmLabel={t('confirmDelete')}
                         deleting={deletingId === word.id}
                         onConfirm={() => handleDeleteConfirmed(word)}
+                        triggerClassName={
+                          active
+                            ? 'text-primary-foreground/70 hover:text-primary-foreground'
+                            : 'opacity-0 group-hover:opacity-100'
+                        }
                       />
                       {!!word.videoCount && word.videoCount > 0 && (
                         <div

--- a/src/fronted/features/video-learning/videoLearningApi.ts
+++ b/src/fronted/features/video-learning/videoLearningApi.ts
@@ -15,6 +15,14 @@ export const videoLearningApi = {
     search: (query: SimpleClipQuery) => backendClient.call('video-learning/search', query),
 
     /**
+     * 删除学习片段；后端同步删除数据库记录与本地片段文件。
+     *
+     * @param key 片段键。
+     * @returns 操作结果。
+     */
+    deleteClip: (key: string) => backendClient.call('video-learning/delete', { key }),
+
+    /**
      * 查询词汇列表。
      *
      * @returns 后端返回的词汇数据。

--- a/src/fronted/i18n/locales/en-US/common.json
+++ b/src/fronted/i18n/locales/en-US/common.json
@@ -43,6 +43,7 @@
     "sortByRecentVideo": "Recent videos",
     "editWord": "Edit word",
     "deleteWord": "Delete word",
+    "deleteClip": "Delete clip",
     "confirmDelete": "Confirm?",
     "wordDeleteFailed": "Failed to delete word",
     "wordField": "Word",

--- a/src/fronted/i18n/locales/en-US/pages.json
+++ b/src/fronted/i18n/locales/en-US/pages.json
@@ -24,6 +24,7 @@
             "button": "Restore Vocabulary Studio Clips from Local"
         },
         "fetchWordsFailed": "Failed to load words",
+        "clipDeleteFailed": "Failed to delete clip",
         "exportSuccess": "Template downloaded",
         "exportFailed": "Export failed, please retry",
         "importSuccess": "Import completed, vocabulary clips synced",

--- a/src/fronted/i18n/locales/zh-CN/common.json
+++ b/src/fronted/i18n/locales/zh-CN/common.json
@@ -43,6 +43,7 @@
     "sortByRecentVideo": "最近添加视频",
     "editWord": "编辑单词",
     "deleteWord": "删除单词",
+    "deleteClip": "删除片段",
     "confirmDelete": "确认删除？",
     "wordDeleteFailed": "删除单词失败",
     "wordField": "单词",

--- a/src/fronted/i18n/locales/zh-CN/pages.json
+++ b/src/fronted/i18n/locales/zh-CN/pages.json
@@ -24,6 +24,7 @@
             "button": "从本地恢复词汇工坊片段"
         },
         "fetchWordsFailed": "获取生词列表失败",
+        "clipDeleteFailed": "删除片段失败",
         "exportSuccess": "模板已下载",
         "exportFailed": "导出失败，请重试",
         "importSuccess": "导入成功，已同步生词片段",


### PR DESCRIPTION
## 背景

词汇工坊此前只有左侧生词列表有删除入口，右侧片段网格无法删除单个学习片段。后端虽已有 `video-learning/delete` 路由，但前端未接线，且删除时不会清理词-片段关联表，会留下孤儿关联导致单词的 `videoCount` 统计虚高。

## 改动

### 后端
- `VideoLearningClipRepository`：`deleteByKey` 替换为 `deleteClipWithWords(key)`，在一个事务内同时删除片段主表与 `dp_video_learning_clip_word` 关联表，消除孤儿关联；旧的 `deleteByKey` 无其他调用方，已移除
- `VideoLearningService.deleteLearningClip` 改用新方法，文件删除逻辑不变

### 前端
- 新增共享组件 `ConfirmDeleteButton`（自原 `WordSidebar` 的 `WordDeleteButton` 抽取）：hover 显示垃圾桶 → 点击变红进入待确认 → 3 秒超时复位 → 再次点击才真正删除，删除中转圈防重复提交
- `ClipGrid` 卡片缩略图右上角 hover 出现删除按钮（与 Info 详情按钮并排），仅对已完成（oss）片段开放，处理中任务不提供删除；`stopPropagation` 避免误触播放
- `VideoLearningPage`：删除后清理缩略图缓存、修正播放选中态（删当前片段则清空选中，删前面片段则平移下标）、当前页删空时回退页码，并刷新片段列表与左侧词汇统计
- `videoLearningApi` 补 `deleteClip`；i18n 补 `deleteClip` / `clipDeleteFailed` 中英文案

## 验证

- 涉及文件 eslint 全过；`tsc` 仅剩基线已有的 `preload.ts` 报错（main 同样存在，与本次无关）
- `yarn test:run`：202 个测试通过；`TagService.test.ts` 的 `better-sqlite3` 原生模块注册失败为本地环境问题，主仓库同样复现

无 drizzle 迁移，无需重新执行 `yarn run download`。