### PR TITLE
fix: 播客模式点击生词发音时不再同时跳转到当前行开始

### DIFF
--- a/src/fronted/features/player/components/translatable-line/word.tsx
+++ b/src/fronted/features/player/components/translatable-line/word.tsx
@@ -364,7 +364,14 @@ const Word = ({word, original, lemma, pop, requestPop, show, alwaysDark, classNa
         }
     };
 
+    /**
+     * 单击单词时播放发音；若用户刚通过拖拽产生选区，则跳过播放。
+     *
+     * 单词点击已被“播放发音”消费，需阻止事件冒泡，
+     * 避免再触发父级字幕行的点击行为（如播客模式的“跳转到行首”）。
+     */
     const handleWordClick = async (event: React.MouseEvent<HTMLSpanElement>) => {
+        event.stopPropagation();
         if (hasMeaningfulSelection(event.currentTarget)) {
             return;
         }


### PR DESCRIPTION
## 背景

播客模式下，视频区以动态字幕流展示字幕，点击任意一行会跳转并播放该行开始位置。但点击可翻译行中的生词时，`Word` 组件的点击事件会沿 DOM 冒泡到字幕行容器的 `onClick`，导致「播放单词发音」和「跳转到当前行开始」两个动作同时触发。

## 修改内容

在 `word.tsx` 的 `handleWordClick` 开头增加 `event.stopPropagation()`：单词点击已被「播放发音」消费，不再触发父级字幕行的点击行为。

词典弹窗（`WordPop`）此前已通过 `FloatingPortal` + `stopPropagation` 隔离了冒泡，本次补齐了单词本体点击这一处遗漏。

## 影响范围确认

`Word` 组件的其他使用方均不依赖单词点击冒泡：
- 主字幕区（`MainSubtitle`）、收藏页（`FavouriteMainSrt`）：父级无 `click` 处理；
- 侧边栏字幕列表（`Subtitle.tsx`）：使用 mousedown/mouseup 选区逻辑，不受 `click` 冒泡影响。

## 验证步骤

1. 开启播客模式，播放带字幕的音频；
2. 点击字幕行内空白处 → 跳转到该行开始并播放（原有功能不受影响）；
3. 点击行内生词 → 仅播放单词发音，不再触发跳转。