### PR TITLE
fix: 视频切分 AI 整理改走结构化输出，支持节流流式回显

### DIFF
--- a/src/backend/services/AiFuncService.ts
+++ b/src/backend/services/AiFuncService.ts
@@ -65,10 +65,17 @@ export class AiFuncServiceImpl implements AiFuncService {
 
     public async formatSplit(text: string): Promise<number> {
         const taskId = await this.dpTaskService.create();
-        this.chatService.chat(taskId, [{
-            role: 'user',
-            content: AiFuncFormatSplitPrompt.promptFunc(text),
-        }]).then();
+        // 走结构化输出：AI 直接返回 schema 校验后的 { formatedText } 对象。
+        // 旧实现用纯文本 chat 把 AI 全文套进 { str: ... } 再 JSON 序列化，
+        // 前端把整个双重编码字符串当章节文本解析，导致切分预览连环报错。
+        this.chatService
+            .run(taskId, AiFuncFormatSplitPrompt.schema, AiFuncFormatSplitPrompt.promptFunc(text))
+            .catch((error) => {
+                // run 内部已捕获流异常并落任务失败；这里只兜住限流等待超时等在进入 run 前抛出的异常。
+                this.dpTaskService.fail(taskId, {
+                    progress: error instanceof Error ? error.message : String(error),
+                });
+            });
         return taskId;
     }
 

--- a/src/backend/services/ChatService.ts
+++ b/src/backend/services/ChatService.ts
@@ -2,15 +2,18 @@ import { inject, injectable } from 'inversify';
 import DpTaskService from '@/backend/services/DpTaskService';
 import TYPES from '@/backend/ioc/types';
 import { ZodType } from 'zod';
-import { ModelMessage, Output, streamText } from 'ai';
+import { Output, streamText } from 'ai';
 import AiProviderService from '@/backend/services/AiProviderService';
-import { AiStringResponse } from '@/common/types/aiRes/AiStringResponse';
 import { WithRateLimit } from '@/backend/utils/concurrency/decorators';
 import { getMainLogger } from '@/backend/infrastructure/logger';
-import { splitSystemMessages } from '@/backend/services/chat/ChatPromptBuilder';
 
 export default interface ChatService {
-    chat(taskId: number, msgs: ModelMessage[]): Promise<void>;
+    /**
+     * 流式产出符合 schema 的结构化对象，并把最终校验结果写入后台任务。
+     * @param taskId 任务编号。
+     * @param resultSchema 期望的结构化输出 schema。
+     * @param promptStr 提示词全文。
+     */
     run(taskId: number, resultSchema: ZodType, promptStr: string): Promise<void>;
 }
 
@@ -27,43 +30,6 @@ export class ChatServiceImpl implements ChatService {
     private logger = getMainLogger('ChatService');
 
     @WithRateLimit('gpt')
-    public async chat(taskId: number, msgs: ModelMessage[]) {
-        const model = this.aiProviderService.getModel('sentenceLearning');
-        if (!model) {
-            this.dpTaskService.fail(taskId, {
-                progress: 'OpenAI api key or endpoint is empty'
-            });
-            return;
-        }
-        this.dpTaskService.process(taskId, {
-            progress: 'AI is thinking...'
-        });
-
-        // v7 起 system 不能放在 messages 里，需拆出来走 system 参数，否则流会静默空转
-        const { system, messages: promptMessages } = splitSystemMessages(msgs);
-        const result = streamText({
-            model,
-            system,
-            messages: promptMessages
-        });
-        const response: AiStringResponse = {
-            str: ''
-        };
-        for await (const chunk of result.textStream) {
-            response.str += chunk;
-            this.dpTaskService.process(taskId, {
-                progress: `AI typing, ${response.str.length} characters`,
-                result: JSON.stringify(response)
-            });
-        }
-
-        this.dpTaskService.finish(taskId, {
-            progress: 'AI has responded',
-            result: JSON.stringify(response)
-        });
-    }
-
-    @WithRateLimit('gpt')
     public async run(taskId: number, resultSchema: ZodType, promptStr: string) {
         const model = this.aiProviderService.getModel('sentenceLearning');
         if (!model) {
@@ -73,27 +39,40 @@ export class ChatServiceImpl implements ChatService {
             return;
         }
         this.logger.debug('stream json start', { taskId });
-        const { partialOutputStream } = streamText({
-            model,
-            output: Output.object({ schema: resultSchema }),
-            prompt: promptStr,
-        });
-        this.dpTaskService.process(taskId, {
-            progress: 'AI is analyzing...'
-        });
-        for await (const partialObject of partialOutputStream) {
-            this.logger.debug('stream json chunk', {
-                taskId,
-                keys: Object.keys(partialObject ?? {}),
+        try {
+            const result = streamText({
+                model,
+                output: Output.object({ schema: resultSchema }),
+                prompt: promptStr,
             });
             this.dpTaskService.process(taskId, {
-                progress: 'AI is analyzing...',
-                result: JSON.stringify(partialObject)
+                progress: 'AI is analyzing...'
+            });
+            for await (const partialObject of result.partialOutputStream) {
+                this.logger.debug('stream json chunk', {
+                    taskId,
+                    keys: Object.keys(partialObject ?? {}),
+                });
+                // 中间态仅用于任务查看器即时展示；最终以 schema 校验后的完整对象为准。
+                this.dpTaskService.process(taskId, {
+                    progress: 'AI is analyzing...',
+                    result: JSON.stringify(partialObject)
+                });
+            }
+            // partialOutputStream 结束不代表输出合法，必须等 output 的校验结果，
+            // 否则残缺对象会被当成最终结果写进任务。
+            const finalObject = await result.output;
+            this.logger.debug('stream json done', { taskId });
+            this.dpTaskService.finish(taskId, {
+                progress: 'AI has responded',
+                result: JSON.stringify(finalObject)
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.error('stream json failed', { taskId, error: message });
+            this.dpTaskService.fail(taskId, {
+                progress: `AI 请求失败：${message}`
             });
         }
-        this.logger.debug('stream json done', { taskId });
-        this.dpTaskService.finish(taskId, {
-            progress: 'AI has responded'
-        });
     }
 }

--- a/src/backend/services/__tests__/AiSdkUpgradeIntegration.test.ts
+++ b/src/backend/services/__tests__/AiSdkUpgradeIntegration.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/backend/infrastructure/settings/store', () => ({
 }));
 
 import { z } from 'zod';
-import { ModelMessage, Output, streamText, LanguageModel } from 'ai';
+import { Output, streamText, LanguageModel } from 'ai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
 import type { LanguageModelV3, LanguageModelV4StreamPart } from '@ai-sdk/provider';
@@ -115,6 +115,20 @@ const buildMockTextModel = (text: string): LanguageModel => {
         doStream: async () => ({
             stream: convertArrayToReadableStream(streamParts),
         }),
+    }) as unknown as LanguageModel;
+};
+
+/**
+ * 构造一个建立流时直接抛错的 mock 模型，用于验证任务失败路径。
+ *
+ * @param error 建流时要抛出的错误。
+ * @returns 可直接传给 streamText 的 LanguageModel。
+ */
+const buildErrorModel = (error: Error): LanguageModel => {
+    return new MockLanguageModelV4({
+        doStream: async () => {
+            throw error;
+        },
     }) as unknown as LanguageModel;
 };
 
@@ -208,8 +222,8 @@ const runTests = (): void => {
             }, 15000);
         });
 
-        describe('ChatServiceImpl.chat（句子学习对话路径）', () => {
-            it('带 system 消息的对话能流式产出文本并完成任务', async () => {
+        describe('ChatServiceImpl.run（结构化输出任务路径）', () => {
+            it('流式产出结构化对象，并在 finish 时写入 schema 校验后的完整结果', async () => {
                 const calls: Array<{ type: string; id: number; info: Record<string, unknown> }> = [];
                 const dpTask: DpTaskService = {
                     create: vi.fn().mockResolvedValue(1),
@@ -224,22 +238,57 @@ const runTests = (): void => {
                     registerTask: vi.fn(),
                 };
                 const provider: AiProviderService = {
-                    getModel: vi.fn(() => buildMockTextModel('这句话可以这样说')),
-                    createModelById: vi.fn(() => buildMockTextModel('这句话可以这样说')),
+                    getModel: vi.fn(() => buildMockTextModel('{"answer": "yes"}')),
+                    createModelById: vi.fn(() => buildMockTextModel('{"answer": "yes"}')),
                 };
                 const chatService = new ChatServiceImpl();
                 (chatService as unknown as { dpTaskService: DpTaskService }).dpTaskService = dpTask;
                 (chatService as unknown as { aiProviderService: AiProviderService }).aiProviderService = provider;
 
-                const messages: ModelMessage[] = [
-                    { role: 'system', content: '你是用户的英语学习伙伴。' },
-                    { role: 'user', content: '这句话怎么理解？' },
-                ];
-                await chatService.chat(1, messages);
+                const schema = z.object({ answer: z.string() });
+                await chatService.run(1, schema, 'Reply with JSON matching the schema.');
+
+                const processes = calls.filter((c) => c.type === 'process');
+                expect(processes.length).toBeGreaterThan(0);
                 const finish = calls.find((c) => c.type === 'finish');
+                expect(calls.find((c) => c.type === 'fail')).toBeUndefined();
                 expect(finish).toBeDefined();
-                const result = JSON.parse(String(finish!.info.result ?? '{}')) as { str: string };
-                expect(result.str).toContain('这句话可以这样说');
+                // 最终结果必须在 finish 里完整写入，且符合 schema（修复点：旧实现 finish 不带结果）。
+                const finalResult = JSON.parse(String(finish!.info.result)) as { answer?: string };
+                expect(schema.safeParse(finalResult).success).toBe(true);
+                expect(finalResult.answer).toBe('yes');
+            }, 15000);
+
+            it('模型流中断时任务被标记失败，而不是永远停在执行中', async () => {
+                const calls: Array<{ type: string; id: number; info: Record<string, unknown> }> = [];
+                const dpTask: DpTaskService = {
+                    create: vi.fn().mockResolvedValue(1),
+                    detail: vi.fn(),
+                    details: vi.fn(),
+                    update: vi.fn(),
+                    process: vi.fn((id, info) => calls.push({ type: 'process', id, info: info as Record<string, unknown> })),
+                    finish: vi.fn((id, info) => calls.push({ type: 'finish', id, info: info as Record<string, unknown> })),
+                    fail: vi.fn((id, info) => calls.push({ type: 'fail', id, info: info as Record<string, unknown> })),
+                    cancel: vi.fn(),
+                    checkCancel: vi.fn(),
+                    registerTask: vi.fn(),
+                };
+                const provider: AiProviderService = {
+                    getModel: vi.fn(() => buildErrorModel(new Error('模型流中断'))),
+                    createModelById: vi.fn(() => buildErrorModel(new Error('模型流中断'))),
+                };
+                const chatService = new ChatServiceImpl();
+                (chatService as unknown as { dpTaskService: DpTaskService }).dpTaskService = dpTask;
+                (chatService as unknown as { aiProviderService: AiProviderService }).aiProviderService = provider;
+
+                const schema = z.object({ answer: z.string() });
+                await chatService.run(1, schema, 'Reply with JSON matching the schema.');
+
+                expect(calls.find((c) => c.type === 'finish')).toBeUndefined();
+                const failed = calls.find((c) => c.type === 'fail');
+                expect(failed).toBeDefined();
+                // AI SDK 会把底层模型错误包装成 NoObjectGeneratedError，这里只断言任务确实被标记失败且带统一前缀。
+                expect(String(failed!.info.progress)).toContain('AI 请求失败');
             }, 15000);
         });
     });
@@ -400,23 +449,7 @@ const runTests = (): void => {
                 installMocks();
             });
 
-            it('真实连接：chat() 能流式回传文本并完成任务', async () => {
-                calls.length = 0;
-                const messages: ModelMessage[] = [
-                    { role: 'system', content: '你是用户的英语学习伙伴，帮他看剧学英语。' },
-                    { role: 'user', content: 'Say exactly: hi there' },
-                ];
-                await chatService.chat(1, messages);
-                const processes = calls.filter((c) => c.type === 'process');
-                const finish = calls.find((c) => c.type === 'finish');
-                expect(processes.length).toBeGreaterThan(0);
-                expect(finish).toBeDefined();
-                const lastProcess = processes[processes.length - 1];
-                const result = JSON.parse(String(lastProcess.info.result ?? '{}')) as { str: string };
-                expect(result.str.trim().length).toBeGreaterThan(0);
-            }, 60000);
-
-            it('真实连接：run() 能流式产出符合 schema 的结构化对象', async () => {
+            it('真实连接：run() 能流式产出符合 schema 的结构化对象，并在 finish 写入完整结果', async () => {
                 calls.length = 0;
                 const schema = z.object({
                     answer: z.string(),
@@ -424,9 +457,10 @@ const runTests = (): void => {
                 await chatService.run(2, schema, 'Reply with JSON matching the schema, e.g. {"answer": "yes"}');
                 const processes = calls.filter((c) => c.type === 'process');
                 expect(processes.length).toBeGreaterThan(0);
-                const lastProcess = processes[processes.length - 1];
-                expect(lastProcess.info.result).toBeDefined();
-                const parsed = JSON.parse(String(lastProcess.info.result)) as { answer?: string };
+                const finish = calls.find((c) => c.type === 'finish');
+                expect(finish).toBeDefined();
+                const parsed = JSON.parse(String(finish!.info.result)) as { answer?: string };
+                expect(schema.safeParse(parsed).success).toBe(true);
                 expect(typeof parsed.answer).toBe('string');
             }, 60000);
         });

--- a/src/common/types/aiRes/AiStringResponse.ts
+++ b/src/common/types/aiRes/AiStringResponse.ts
@@ -1,3 +1,0 @@
-export interface AiStringResponse {
-    str: string;
-}

--- a/src/fronted/features/split/splitStore.ts
+++ b/src/fronted/features/split/splitStore.ts
@@ -4,10 +4,13 @@
 import { create } from 'zustand';
 import { persist, subscribeWithSelector } from 'zustand/middleware';
 import { ChapterParseResult } from '@/common/types/chapter-result';
+import { DpTaskState } from '@/common/contracts/dp-task';
 import MediaUtil from '@/common/utils/MediaUtil';
 import useDpTaskCenter from '@/fronted/hooks/useDpTaskCenter';
+import { getRendererLogger } from '@/fronted/log/simple-logger';
 import { swrApiMutate } from '@/fronted/lib/swr-util';
 import StrUtil from '@/common/utils/str-util';
+import toast from 'react-hot-toast';
 import { splitApi } from './splitApi';
 
 /** 带有前端任务关联信息的章节解析结果。 */
@@ -95,15 +98,44 @@ const useSplit = create(
                 }
                 const userInput = get().userInput;
                 set({ inputable: false });
+                // 流式打字机的节流窗口：partial 每个 chunk 都到，直接灌进输入框
+                // 会让预览按同频走一次后端解析 IPC（正式环境曾因此刷屏报错）。
+                const streamPaintIntervalMs = 300;
+                let lastPaintedAt = 0;
                 await useDpTaskCenter.getState().register(() => splitApi.formatSplit(userInput), {
+                    // 流式中间态：把已生成的 formatedText 渐进填入输入框做打字机效果；
+                    // 中间态是残缺 JSON/残缺文本，解析失败直接跳过等下一个 chunk，不报错。
                     onUpdated: (task) => {
-                        if (StrUtil.isBlank(task?.result)) return;
-                        useSplit.setState({
-                            userInput: task.result
-                        });
+                        const now = Date.now();
+                        if (task.status !== DpTaskState.IN_PROGRESS || now - lastPaintedAt < streamPaintIntervalMs) {
+                            return;
+                        }
+                        lastPaintedAt = now;
+                        try {
+                            const parsed = JSON.parse(task.result ?? '') as { formatedText?: string };
+                            if (StrUtil.isNotBlank(parsed?.formatedText)) {
+                                set({ userInput: parsed.formatedText });
+                            }
+                        } catch {
+                            // partial 还没成 JSON 时静默跳过；最终结果以 onFinish 的校验结果为准。
+                        }
                     },
-                    onFinish: () => {
-                        useSplit.setState({ inputable: true });
+                    onFinish: (task) => {
+                        set({ inputable: true });
+                        if (task.status !== DpTaskState.DONE) {
+                            toast.error(task.progress ?? 'AI 整理失败');
+                            return;
+                        }
+                        try {
+                            const parsed = JSON.parse(task.result ?? '') as { formatedText?: string };
+                            if (StrUtil.isBlank(parsed?.formatedText)) {
+                                throw new Error('AI 返回结果缺少 formatedText 字段');
+                            }
+                            set({ userInput: parsed.formatedText });
+                        } catch (error) {
+                            splitLogger.error('AI 整理结果解析失败', { error });
+                            toast.error('AI 整理结果无法解析，请重试');
+                        }
                     },
                 });
             }
@@ -121,6 +153,8 @@ useSplit.setState({
 // 用递增序号丢弃过期响应，避免旧预览覆盖用户最新输入。
 let previewRequestSequence = 0;
 
+const splitLogger = getRendererLogger('SplitStore');
+
 useSplit.subscribe(
     (s) => s.userInput,
     async (topic) => {
@@ -129,7 +163,19 @@ useSplit.subscribe(
             useSplit.setState({ parseResult: [] });
             return;
         }
-        const result = await splitApi.previewSplit(topic);
+        let result: ChapterParseResult[];
+        try {
+            result = await splitApi.previewSplit(topic);
+        } catch (error) {
+            // 用户正在逐字输入时（如只敲了半个时间戳）解析必然失败，
+            // 属于预期中的瞬态：清空预览并留 warn 日志，而不是未处理拒绝刷屏。
+            splitLogger.warn('章节预览解析失败，已清空预览', { error });
+            if (requestSequence !== previewRequestSequence) {
+                return;
+            }
+            useSplit.setState({ parseResult: [] });
+            return;
+        }
         if (requestSequence !== previewRequestSequence) {
             return;
         }


### PR DESCRIPTION
## 背景

正式环境日志（2026-09-05）中 `split-video/preview` 几秒内报 30+ 条 `Invalid time format`，同期 renderer 10+ 条 `unhandled rejection`。

根因链：

1. `AiFuncService.formatSplit` 走纯文本 `ChatService.chat()`，提示词要求 AI 输出 JSON `{"formatedText": "..."}`，而 `chat()` 把全文套进 `{ str: ... }` 再 `JSON.stringify` 写入 task.result —— 双重编码；
2. 前端 `splitStore.aiFormat` 把 `task.result` 原样灌进章节输入框；
3. `chat()` 流式期间每 chunk 更新一次 result，`onUpdated` 每次都触发 `split-video/preview` 解析，中间态连环报错刷屏；
4. 预览订阅回调无 catch，解析失败直接变成未处理拒绝。

## 改动

- **ChatService**：删除 `chat()` 与 `AiStringResponse`（唯一调用方已迁移）；`run()` 补全契约——流结束后 `await result.output` 拿 schema 校验后的完整对象写入 `finish`（旧实现 finish 不带结果），流失败显式落 `FAILED`，任务不再永远卡在执行中
- **AiFuncService.formatSplit**：改走 `run()` 结构化输出，AI 直接返回 `{ formatedText }`；限流等待超时等异常也显式落任务失败
- **splitStore**：
  - `onUpdated` 节流 300ms 把 partial 的 `formatedText` 渐进填入输入框（打字机回显），partial 未成 JSON 时跳过等下一 chunk
  - `onFinish` 用最终校验结果覆盖输入框；任务失败/取消/结果解析失败显式 `toast.error`
  - 预览订阅回调补 try/catch：逐字输入的瞬态解析失败清空预览并记 warn，不再产生未处理拒绝
- **测试**：删除 `chat()` 路径测试；新增 `run()` 离线回归（finish 写入校验后完整结果、流中断落失败态）；真连测试同步更新

## 验证步骤

1. `yarn test:run`：31 个文件 227 通过（9 skipped 为真连门控）；改动文件 eslint / `tsc --noEmit` 干净
2. 切分页输入章节文本 → 点击 AI 整理：输入框打字机式渐进回显，结束后为最终整理结果；预览全程无报错刷屏
3. 配置错误的 API Key 或断网触发失败：toast 显示失败原因，任务查看器中任务为失败态（不再卡"执行中"）

## 截图

纯链路修复，UI 布局无变化。

## 其他

- 不涉及 `drizzle/` 迁移，不需要重新执行 `yarn run download`
- AI SDK 会把底层模型错误包装为 `NoObjectGeneratedError`，任务进度里显示统一前缀「AI 请求失败：…」，上游原始错误可在 JSONL 日志 `ChatService stream json failed` 中检索