### PR TITLE
feat: 为 Linux 新增 AppImage 安装包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           choco install wixtoolset
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+      # AppImage maker (@reforged/maker-appimage) 需要系统提供 mksquashfs，
+      # 显式安装而不依赖 runner 镜像恰好预装
+      - name: Install squashfs-tools (Linux only)
+        if: matrix.os.name == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y squashfs-tools
       - name: Install dependencies
         if: matrix.os.name != 'windows'
         run: yarn install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -171,6 +171,38 @@ Linux 提供 `.deb` 和 `.rpm` 两种安装包格式，请根据发行版选择�
 - `.rpm`：适用于 Fedora、openSUSE、RHEL 及其衍生发行版，下载后使用 `sudo rpm -i <安装包>` 或图形界面安装
 
 ---
+## Linux
+
+### AppImage（免安装，推荐）
+
+1. 在 [Latest Release](https://github.com/solidSpoon/DashPlayer/releases/latest) 页面下载以 `.AppImage` 结尾的安装包
+2. 添加可执行权限后直接运行：
+
+```bash
+chmod +x DashPlayer-*.AppImage
+./DashPlayer-*.AppImage
+```
+
+3. 开始使用吧！
+
+> 如果启动时提示缺少 FUSE（`dlopen(): error loading libfuse.so.2`），请安装 `libfuse2`（Debian/Ubuntu：`sudo apt install libfuse2`），或改用 `./DashPlayer-*.AppImage --appimage-extract-and-run` 运行。
+
+### deb / rpm
+
+1. 在 [Latest Release](https://github.com/solidSpoon/DashPlayer/releases/latest) 页面下载 `.deb`（Debian/Ubuntu 系）或 `.rpm`（Fedora/RHEL/openSUSE 系）安装包
+2. 使用系统包管理器安装：
+
+```bash
+# Debian/Ubuntu 系
+sudo dpkg -i DashPlayer-*.deb
+
+# Fedora/RHEL 系
+sudo rpm -i DashPlayer-*.rpm
+```
+
+3. 开始使用吧！
+
+---
 # 使用指南
 
 > 字幕生成为内置本地模型，开箱即用；AI 功能（字幕翻译、查单词、整句学习）需配置 OpenAI 接口，具体方法及详细指南请看[Wiki](https://solidspoon.xyz/DashPlayer/home.html)

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,8 @@ import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
 import { MakerWix } from '@electron-forge/maker-wix';
+// Forge 官方没有 AppImage maker，使用社区维护的 ReForged 实现（覆盖 Arch/NixOS 等无 deb/rpm 的发行版）
+import { MakerAppImage } from '@reforged/maker-appimage';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
@@ -80,6 +82,26 @@ const config: ForgeConfig = {
                 bin: 'dash-player',
                 productName: 'DashPlayer',
                 icon: './assets/icons/icon.png',
+            },
+        }),
+        // AppImage：单文件免安装格式，产物命名 DashPlayer-<version>-<arch>.AppImage。
+        // bin 必须与 packagerConfig.executableName 一致，maker 会按它校验打包产物内的可执行文件。
+        // icon 给出 hicolor 多尺寸集合，maker 自动把最大尺寸作为 .DirIcon 默认图标。
+        new MakerAppImage({
+            options: {
+                name: 'dash-player',
+                bin: 'dash-player',
+                productName: 'DashPlayer',
+                icon: {
+                    '16x16': './assets/icons/16x16.png',
+                    '24x24': './assets/icons/24x24.png',
+                    '32x32': './assets/icons/32x32.png',
+                    '48x48': './assets/icons/48x48.png',
+                    '64x64': './assets/icons/64x64.png',
+                    '128x128': './assets/icons/128x128.png',
+                    '256x256': './assets/icons/256x256.png',
+                },
+                categories: ['AudioVideo', 'Video'],
             },
         }),
         new MakerWix({

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@electron-forge/plugin-vite": "^7.11.2",
     "@electron/fuses": "^2.1.3",
     "@electron/rebuild": "^4.2.0",
+    "@reforged/maker-appimage": "^5.3.1",
     "@tailwindcss/typography": "^0.5.12",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,7 +622,7 @@
     source-map-support "^0.5.13"
     username "^5.1.0"
 
-"@electron-forge/maker-base@7.11.2":
+"@electron-forge/maker-base@7.11.2", "@electron-forge/maker-base@^6.0.0 || ^7.0.0":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@electron-forge/maker-base/-/maker-base-7.11.2.tgz#9388c64094dda139a032703cb69f4fcb29484fa9"
   integrity sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==
@@ -2684,6 +2684,21 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.3.tgz#5a58fbae3deefb7f8cfe6ea314287d699eb694a9"
   integrity sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==
 
+"@reforged/maker-appimage@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@reforged/maker-appimage/-/maker-appimage-5.3.1.tgz#b3914caf80772d733f632f972d8d36c191b69e1e"
+  integrity sha512-lJqSZO+/qZmkarZ9pKZgE5DnZxuEvRe7JXupLo6YSTEOL+bkETthWP3XCLgAxLDsLCwPuPmF1tooYCt2dcIRCQ==
+  dependencies:
+    "@electron-forge/maker-base" "^6.0.0 || ^7.0.0"
+    "@reforged/maker-types" "^2.2.0"
+    "@spacingbat3/lss" "^1.0.0"
+    semver "^7.3.8"
+
+"@reforged/maker-types@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@reforged/maker-types/-/maker-types-2.2.0.tgz#9c51547e947a292c7757cbed70560dbcc8dca884"
+  integrity sha512-14B5Tu6fG2AWgH+bdsfJaQkAi8Bc7YC8GmMuNEWCJupU9IhvKHrdte3GAncBYO10yqSbsQx7Pi9xpyveJ5vL+Q==
+
 "@remix-run/router@1.23.4":
   version "1.23.4"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.4.tgz#d2becd2afca4a40c30a659d913b9b0bcc28bced8"
@@ -2963,6 +2978,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
   integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
+
+"@spacingbat3/lss@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@spacingbat3/lss/-/lss-1.2.0.tgz#0d04ddee2e41682fd09b7eda67d43c1d49e28c05"
+  integrity sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==
 
 "@standard-schema/spec@^1.0.0":
   version "1.0.0"
@@ -13221,15 +13241,15 @@ semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8, semver@^7.6.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
 semver@^7.5.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
-
-semver@^7.6.3:
-  version "7.8.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
-  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## 背景

目前 Linux 只提供 `.deb` / `.rpm` 两种安装包，分别只覆盖 Debian 系和 RHEL 系发行版。Arch、NixOS 等没有对应包格式的发行版用户无法方便安装（参照同类应用，AppImage 是免安装、跨发行版的通用格式）。

## 变更

- `forge.config.ts`：新增 `@reforged/maker-appimage` maker（Electron Forge 官方没有 AppImage maker，选用社区 ReForged 实现，持续维护中），产出 `DashPlayer-<version>-<arch>.AppImage`
  - `bin` 与 `packagerConfig.executableName` 保持一致（`dash-player`）
  - icon 使用 `assets/icons/` 下现成的 16–256 多尺寸 PNG 集合，maker 自动取最大尺寸作 `.DirIcon`
  - desktop 分类 `AudioVideo` / `Video`
- `.github/workflows/release.yml`：Linux job 显式安装 `squashfs-tools`（AppImage maker 依赖系统 `mksquashfs`，显式声明而不依赖 runner 镜像恰好预装）
- `README.md`：安装指南补充 Linux 章节（AppImage / deb / rpm）
- `package.json` / `yarn.lock`：新增 devDependency `@reforged/maker-appimage@^5.3.1`

不需要重新执行 `yarn run download`，不涉及 `drizzle/` 迁移。

## 验证

- `npx tsc --noEmit` 通过（仓库存在一个与本 PR 无关的历史遗留报错：`src/preload.ts(97,20)` `SimpleEvent` 未定义，干净 main 上同样复现）
- maker 配置已按 `@reforged/maker-appimage@5.3.1` 的类型与源码核对（`defaultPlatforms: ["linux"]`，仅在 Linux 构建机生效；产物命名 `DashPlayer-<version>-<arch>.AppImage`，publisher 会随现有流程上传到 Release）
- 真实产物需在下一次发版构建中确认：AppImage 会与 deb/rpm 一起出现在 Release 资产列表