### PR TITLE
build: 发版时构建 whisper.cpp 核显运行时并接入 download 脚本

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,5 +32,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
+    with:
+      release_tag: ${{ steps.release.outputs.tag_name }}
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,10 @@ jobs:
   release-please:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      # 透传发版 tag。steps 上下文只在 job outputs 处可用，下游 job 的
+      # with 里必须经 needs 引用本 output，直接写 steps.* 会导致整个
+      # workflow 文件解析失败（Unrecognized named-value）。
+      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
@@ -33,6 +37,6 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
     with:
-      release_tag: ${{ steps.release.outputs.tag_name }}
+      release_tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,89 @@ on:
   # 供 release-please.yml 在发版 PR 合并后以 workflow_call 直接调用
   # （GITHUB_TOKEN 打的 tag 不会触发 push 事件，不能只靠下面的 tag 触发器）
   workflow_call:
+    inputs:
+      # 发版 tag（如 v6.12.0）。workflow_call 上下文是 main 分支 push，
+      # 取不到 tag 名，由 release-please 显式传入，供运行时资产上传到对应 Release
+      release_tag:
+        type: string
+        required: false
+        default: ''
   push:
     tags: ['v*']
 permissions:
   contents: write
 jobs:
+  # whisper.cpp 核显运行时先行构建并挂到 Release，供后续 publish 中的
+  # `yarn run download` 取用；单个目标失败不阻塞其余目标与 app 构建，
+  # 缺失资产在下载时跳过并在识别时显式报错
+  whisper-cpp-runtime:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-x64, os: ubuntu-22.04, gpu: vulkan }
+          - { name: win32-x64, os: windows-2022, gpu: vulkan }
+          - { name: darwin-arm64, os: macos-14, gpu: metal }
+          - { name: darwin-x64, os: macos-15-intel, gpu: metal }
+    runs-on: ${{ matrix.os }}
+    env:
+      # 运行时基于固定版本的 whisper.cpp 构建；parakeet-cli 输出格式是
+      # 解析契约（见 WhisperCppCli.parseOutput），升级前需重新验证
+      WHISPER_CPP_REF: 52a939a2a762224e255d366c1182b2af4dd1a032
+    steps:
+      - name: Checkout whisper.cpp
+        uses: actions/checkout@v5
+        with:
+          repository: ggml-org/whisper.cpp
+          ref: ${{ env.WHISPER_CPP_REF }}
+      - name: Install Vulkan toolchain (Linux only)
+        if: matrix.gpu == 'vulkan' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libvulkan-dev glslang-tools
+      - name: Install Vulkan SDK (Windows only)
+        if: matrix.gpu == 'vulkan' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          curl.exe -L -o "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" "https://sdk.lunarg.com/sdk/download/1.3.290.0/windows/VulkanSDK-1.3.290.0-Installer.exe"
+          & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\1.3.290.0"
+      - name: Configure (Vulkan)
+        if: matrix.gpu == 'vulkan'
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=OFF
+      - name: Configure (Metal)
+        if: matrix.gpu == 'metal'
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DCMAKE_OSX_ARCHITECTURES=${{ contains(matrix.name, 'arm64') && 'arm64' || 'x86_64' }} -DBUILD_SHARED_LIBS=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=OFF
+      - name: Build
+        run: cmake --build build --config Release --target parakeet-cli -j 4
+      - name: Package
+        shell: bash
+        run: |
+          mkdir -p stage
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp build/bin/Release/parakeet-cli.exe stage/parakeet-cli.exe
+            (cd stage && 7z a "../whisper-cpp-${{ matrix.name }}.zip" parakeet-cli.exe)
+          else
+            cp build/bin/parakeet-cli stage/parakeet-cli
+            (cd stage && tar czf "../whisper-cpp-${{ matrix.name }}.tar.gz" parakeet-cli)
+          fi
+      - name: Upload to release
+        # workflow_call 链路用传入的 release_tag；tag push 链路用当前 ref。
+        # 手动触发（无 tag、无发版）时仅验证构建，不上传
+        if: inputs.release_tag != '' || github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          TAG="${{ inputs.release_tag || github.ref_name }}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            ASSET="whisper-cpp-${{ matrix.name }}.zip"
+          else
+            ASSET="whisper-cpp-${{ matrix.name }}.tar.gz"
+          fi
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          gh release upload "$TAG" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber
   build:
+    needs: whisper-cpp-runtime
+    if: ${{ !cancelled() }}
     strategy:
       # 某个平台构建失败时，其他平台继续构建发布，不互相拖累
       fail-fast: false

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -388,6 +388,8 @@ const ffmpegUrls = {
 ////////////////////
 setProxy();
 const dir = path.join(process.cwd(), 'lib');
+// 当前源码版本号：whisper.cpp 运行时资产按发版 tag 发布，与该版本一一对应
+const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
 mkdirp(dir);
 
 const platform = process.env.npm_config_platform || os.platform()
@@ -484,5 +486,51 @@ const arch = process.env.npm_config_arch || os.arch()
             outputPath: ttsExePath,
             binaryNameCandidates: [ttsExeName],
         });
+    }
+}
+
+{
+    // whisper.cpp 离线识别 CLI（whisper.cpp 引擎的核显加速运行时）。
+    // 资产随应用 Release 一起发布：release.yml 的 whisper-cpp-runtime 任务
+    // 在发版时构建四个目标并上传；本段从当前版本对应的 Release 下载。
+    const platformDir = platform === 'darwin' ? 'darwin' : platform === 'win32' ? 'win32' : 'linux';
+    const archDir = arch === 'arm64' ? 'arm64' : 'x64';
+    const basePath = path.join(dir, 'whisper-cpp', archDir, platformDir);
+    mkdirp(basePath);
+
+    const exeName = platform === 'win32' ? 'parakeet-cli.exe' : 'parakeet-cli';
+    const exePath = path.join(basePath, exeName);
+    const res = await verifyExistence({ dir: basePath, file: exeName });
+
+    // 核显运行时仅覆盖主流桌面平台；其余平台由 sherpa-onnx 引擎兜底
+    const supportedArchs = { linux: ['x64'], win32: ['x64'], darwin: ['arm64', 'x64'] };
+    if (res === 'need_download') {
+        if (!supportedArchs[platform]?.includes(arch)) {
+            console.info(chalk.yellow(`=> whisper.cpp 暂不提供 ${platform}/${arch} 运行时，已跳过；whisper.cpp 引擎在该平台不可用，请使用 sherpa-onnx 引擎`));
+        } else {
+            const version = packageJson.version;
+            const assetName = `whisper-cpp-${platform}-${arch}.tar.gz`;
+            const assetUrl = `https://github.com/solidSpoon/DashPlayer/releases/download/v${version}/${assetName}`;
+            // 预检资产是否存在：download() 对任何失败都会终止整个脚本，
+            // 而资产缺失（本地开发、历史版本）是可跳过的合法状态，只对 404 放行跳过
+            let assetExists = true;
+            try {
+                await axios.head(assetUrl, { headers: getGithubAuthHeaders(assetUrl) });
+            } catch (error) {
+                if (error?.response?.status === 404) {
+                    assetExists = false;
+                }
+            }
+            if (!assetExists) {
+                console.info(chalk.yellow(`=> whisper.cpp 运行时资产尚未随 v${version} 发布，已跳过；识别引擎可暂用 sherpa-onnx，或手动将二进制放置到 ${exePath}`));
+            } else {
+                console.info(chalk.blue(`=> whisper.cpp target: ${exePath}`));
+                await downloadAndExtractBinaryFromArchive({
+                    url: assetUrl,
+                    outputPath: exePath,
+                    binaryNameCandidates: ['parakeet-cli', 'parakeet-cli.exe'],
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
## 背景

#242 已将 whisper.cpp 核显引擎作为本地字幕识别的默认引擎合入待发版队列，但当时运行时分发未闭环（官方无 Linux/Windows Vulkan 预编译包）。本 PR 补齐：发版时自动构建运行时并接入 `yarn run download`。

## 改动

### release.yml 新增 whisper-cpp-runtime 任务

在 app 四平台构建之前运行（build 增加 needs），按矩阵构建 whisper.cpp 固定提交（`52a939a2`）的 `parakeet-cli` 并上传到本次 Release：

| 目标 | runner | 后端 | 关键构建参数 |
|---|---|---|---|
| linux-x64 | ubuntu-22.04 | Vulkan | `apt install libvulkan-dev glslang-tools`，`GGML_NATIVE=OFF` |
| win32-x64 | windows-2022 | Vulkan | LunarG SDK 1.3.290.0 静默安装（URL 已预检可达） |
| darwin-arm64 / darwin-x64 | macos-14 / macos-15-intel | Metal | `GGML_METAL_EMBED_LIBRARY=ON`（metallib 内嵌，单文件分发） |

- `BUILD_SHARED_LIBS=OFF` 静态链接，产物为单个二进制
- CPU 用 `GGML_NATIVE=OFF` 保守基线：核显引擎的算力瓶颈在 GPU，CPU 回退场景由 sherpa-onnx 引擎承担，不值得为此引入多变体分发
- `fail-fast: false`，单目标失败不阻塞其余目标；`build` 加 `needs` + `!cancelled()`，即使运行时部分失败 app 构建照常（缺失资产在下载时显式跳过）

### release-please.yml 传参

workflow_call 上下文是 main 分支 push，取不到 tag 名；通过新增入参 `release_tag` 把 release-please 的 tag 显式传给 release.yml，运行时资产上传到对应 Release。

### download.mjs 新增 whisper.cpp 段

按 `package.json` 版本从对应 Release 下载 `whisper-cpp-<platform>-<arch>.tar.gz` 到 `lib/whisper-cpp/<arch>/<platform>/parakeet-cli`：

- 手动放置过二进制时 `verifyExistence` 跳过下载（开发机路径，#242 已注明）
- 404（本地开发尚未发版、历史版本 checkout）时**显式提示后跳过**，不阻塞 ffmpeg/sherpa 等其余运行时下载；whisper.cpp 引擎在识别时会因缺二进制报错，用户可切回 sherpa-onnx——不做静默降级
- 其余错误（网络等）沿用现有失败路径终止脚本

## 验证

- 两个 workflow YAML 解析通过；`node --check scripts/download.mjs` 通过
- 本机实跑 `node scripts/download.mjs`：手动放置的二进制被识别跳过下载；移除后走 404 提示跳过，退出码 0
- `verifyExistence`/`downloadAndExtractBinaryFromArchive` 为既有函数，未改动其行为

## 发版联动

合并后下一次 release-please 发版：runtime 任务随 tag 构建四个运行时资产挂到 Release → 该版本起 `yarn run download` / 打包产物自带 whisper.cpp 运行时。