### PR TITLE
fix: 修 whisper.cpp 运行时 Vulkan 目标的工具链（glslc 与 SPIRV-Headers）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,30 @@ jobs:
           ref: ${{ env.WHISPER_CPP_REF }}
       - name: Install Vulkan toolchain (Linux only)
         if: matrix.gpu == 'vulkan' && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libvulkan-dev glslang-tools
+        run: |
+          # ggml 的 ggml-vulkan 要的是 glslc（find_package(Vulkan COMPONENTS glslc REQUIRED)）
+          # 与 SPIRV-Headers 的 cmake config，Ubuntu 自带的 glslang-tools 只提供
+          # glslangValidator，装完仍然找不到 glslc；与 llama.cpp 一致，
+          # 从 LunarG 的 jammy 源装完整 SDK（源码里两处硬依赖都在里面）
+          sudo mkdir -p /etc/apt/keyrings
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/keyrings/lunarg.asc > /dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/lunarg.asc] https://packages.lunarg.com/vulkan jammy main" | sudo tee /etc/apt/sources.list.d/lunarg-vulkan-jammy.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install -y vulkan-sdk
       - name: Install Vulkan SDK (Windows only)
         if: matrix.gpu == 'vulkan' && runner.os == 'Windows'
         shell: pwsh
+        env:
+          # 必须用 1.4.x：1.3.290 的 SDK 不带 SPIRV-Headers 的 cmake config，
+          # 而 ggml 的 ggml-vulkan 是 find_package(SPIRV-Headers CONFIG REQUIRED)
+          # （实测 1.3.290 报 Could not find a package configuration file
+          # provided by "SPIRV-Headers"）；与 llama.cpp 的版本保持一致
+          VULKAN_VERSION: 1.4.357.0
         run: |
-          curl.exe -L -o "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" "https://sdk.lunarg.com/sdk/download/1.3.290.0/windows/VulkanSDK-1.3.290.0-Installer.exe"
+          curl.exe -L -o "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" "https://sdk.lunarg.com/sdk/download/$env:VULKAN_VERSION/windows/vulkansdk-windows-X64-$env:VULKAN_VERSION.exe"
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
-          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\1.3.290.0"
+          Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_VERSION"
+          Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$env:VULKAN_VERSION\bin"
       - name: Configure (Vulkan)
         if: matrix.gpu == 'vulkan'
         env:

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -611,8 +611,8 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
             {
                 bin: 'glslc',
                 hint: platform === 'win32'
-                    ? 'Windows: 安装 LunarG Vulkan SDK（提供 Vulkan 头文件与 glslc）'
-                    : 'Linux: apt install libvulkan-dev glslang-tools',
+                    ? 'Windows: 安装 LunarG Vulkan SDK 1.4.x（同时提供 glslc 与 SPIRV-Headers）'
+                    : 'Linux: 需 glslc + SPIRV-Headers（Ubuntu 24.04: apt install glslc libvulkan-dev spirv-headers；22.04: 用 LunarG 的 jammy 源装 vulkan-sdk）',
             },
         ];
     for (const tool of requiredTools) {


### PR DESCRIPTION
## 背景

`release.yml` 的 `whisper-cpp-runtime` 矩阵首次干跑（run 34483018648，勾了 `runtime_only`）结果：

| 目标 | 结果 |
|---|---|
| darwin-arm64 (macos-14, Metal) | ✅ success |
| darwin-x64 (macos-15-intel, Metal) | ✅ success |
| linux-x64 (ubuntu-22.04, Vulkan) | ❌ Configure (Vulkan) |
| win32-x64 (windows-2022, Vulkan) | ❌ Configure (Vulkan) |

两个失败都是 ggml 对 Vulkan 工具链的硬依赖没满足，`build` 按设计 skipped。

**linux-x64**

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Vulkan (missing: glslc) (found version "1.3.204")
  ggml/src/ggml-vulkan/CMakeLists.txt:9 (find_package)
```

`ggml-vulkan/CMakeLists.txt:9` 是 `find_package(Vulkan COMPONENTS glslc REQUIRED)`，而 Ubuntu 的 `glslang-tools` 只提供 `glslangValidator`。

**win32-x64**

```
-- Found Vulkan: C:/VulkanSDK/1.3.290.0/Lib/vulkan-1.lib (found version "1.3.290") found components: glslc glslangValidator
CMake Error at ggml/src/ggml-vulkan/CMakeLists.txt:14 (find_package):
  Could not find a package configuration file provided by "SPIRV-Headers"
```

Vulkan 和 glslc 都装上了，但 SDK 1.3.290 不带 `SPIRV-Headers` 的 cmake config。

## 改动

- **Linux**：改为从 LunarG 的 jammy 源装 `vulkan-sdk`（`libvulkan-dev` + `glslang-tools` 的组合满足不了 `glslc`）。签名走 `/etc/apt/keyrings` + `signed-by`，不用已废弃的 `apt-key`。
- **Windows**：SDK 升到 `1.4.357.0`（安装包 `vulkansdk-windows-X64-<版本>.exe`，已预检 200），并把 `<SDK>\bin` 加进 `GITHUB_PATH`。
- 两处都与 llama.cpp 使用的同一套 ggml 的官方发版配置对齐（他们 22.04 也用 LunarG 源，Windows 也是 1.4.357.0），不是新摸索的方案。
- `scripts/download.mjs` 里本地源码构建的 `glslc` 提示同步改成真实依赖：原来的 `apt install libvulkan-dev glslang-tools` 装完仍然缺 `glslc`。

## 验证

合入后再手动触发一次 `release.yml` 干跑（勾 `runtime_only`），四个目标应全绿；若仍失败请把失败步骤日志发出来。
