### PR TITLE
fix: 修复打包版启动崩溃（scoped 依赖丢失 + 原生动态库未解包）并按平台裁剪原生库

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -90,10 +90,20 @@ const config: ForgeConfig = {
                 '/node_modules/tar',
                 '/node_modules/type-fest',
                 '/node_modules/undici-types',
-                '/node_modules/yallist',            ];
+                '/node_modules/yallist',
+            ];
 
+            // ignore 返回 true 时 electron-packager 会连整棵子树一起跳过，
+            // 所以除了白名单路径自身，还必须放行它的所有祖先目录：
+            // 只写 `/node_modules/@huggingface/transformers` 而漏掉父目录
+            // `/node_modules/@huggingface` 时，scoped 依赖会整体丢包
+            // （打包版启动即 Cannot find module '@huggingface/transformers'）。
             for (const prefix of keptNodeModulePrefixes) {
-                if (file === prefix || file.startsWith(`${prefix}/`)) {
+                // 兼容 `/node_modules/@img/` 这类带结尾斜杠的写法
+                const normalized = prefix.replace(/\/+$/, '');
+                if (file === normalized
+                    || file.startsWith(`${normalized}/`)
+                    || normalized.startsWith(`${file}/`)) {
                     return false;
                 }
             }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -111,7 +111,10 @@ const config: ForgeConfig = {
             return true;
         },
         asar: {
-            unpack: '**/*.{wasm,node}',
+            // 原生库必须解到 app.asar.unpacked：dyld/ld.so 读不了 asar 内部，
+            // 例如 onnxruntime 的 binding.node 会按 @rpath（自身目录）找
+            // libonnxruntime.*，只解包 .node 会导致 dlopen 报 Library not loaded。
+            unpack: '**/*.{wasm,node,dylib,so,so.*}',
         },
         icon: './assets/icons/icon',
         extraResource: ['./drizzle', './lib', './scripts', './resources'],

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -13,6 +13,79 @@ import packageJson from './package.json';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
+/**
+ * 判断路径是否存在（fs/promises 没有 exists）。
+ *
+ * @param target 待检查的绝对路径。
+ * @returns 路径存在时返回 true。
+ */
+const pathExists = async (target: string): Promise<boolean> => {
+    try {
+        await fs.access(target);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * 打包时裁掉非目标平台/架构的原生库变体。
+ *
+ * 背景：onnxruntime-node 会把 darwin/linux/win32 × x64/arm64 六套预编译库
+ * （约 208MB）一起装进 node_modules，其中 5/6 对当前产物毫无用处；这些异架构
+ * ELF 还会让 Linux RPM 打包阶段的 brp-strip 报 "Unable to recognise the
+ * format" 而整包失败。sharp 的平台包、better-sqlite3 的预编译目录同理。
+ *
+ * @param buildPath 打包暂存目录（应用根目录）。
+ * @param platform 目标平台（darwin/linux/win32/mas）。
+ * @param arch 目标架构（x64/arm64/ia32）。
+ */
+const pruneForeignNativeVariants = async (buildPath: string, platform: string, arch: string): Promise<void> => {
+    // mac App Store 构建的原生库目录名与 darwin 一致
+    const nativePlatform = platform === 'mas' ? 'darwin' : platform;
+
+    const drop = async (target: string): Promise<void> => {
+        if (!await pathExists(target)) return;
+        await fs.rm(target, { recursive: true, force: true });
+        console.log(`[prune-native] 移除 ${path.relative(buildPath, target)}`);
+    };
+
+    // onnxruntime-node：bin/napi-v3/<platform>/<arch> 只保留目标组合
+    const variantsRoot = path.join(buildPath, 'node_modules/onnxruntime-node/bin/napi-v3');
+    if (await pathExists(variantsRoot)) {
+        for (const variantPlatform of await fs.readdir(variantsRoot)) {
+            const platformDir = path.join(variantsRoot, variantPlatform);
+            if (variantPlatform !== nativePlatform) {
+                await drop(platformDir);
+                continue;
+            }
+            for (const variantArch of await fs.readdir(platformDir)) {
+                if (variantArch !== arch) {
+                    await drop(path.join(platformDir, variantArch));
+                }
+            }
+        }
+    }
+
+    // sharp：@img/sharp-<platform>-<arch>、@img/sharp-libvips-<platform>-<arch>
+    const imgRoot = path.join(buildPath, 'node_modules/@img');
+    if (await pathExists(imgRoot)) {
+        for (const pkg of await fs.readdir(imgRoot)) {
+            if (!pkg.startsWith('sharp-') || pkg.includes(`-${nativePlatform}-${arch}`)) continue;
+            await drop(path.join(imgRoot, pkg));
+        }
+    }
+
+    // better-sqlite3：bin/<platform>-<arch>-<abi> 只保留目标组合
+    const sqliteBinRoot = path.join(buildPath, 'node_modules/better-sqlite3/bin');
+    if (await pathExists(sqliteBinRoot)) {
+        for (const variant of await fs.readdir(sqliteBinRoot)) {
+            if (variant.startsWith(`${nativePlatform}-${arch}-`)) continue;
+            await drop(path.join(sqliteBinRoot, variant));
+        }
+    }
+};
+
 
 const config: ForgeConfig = {
     packagerConfig: {
@@ -208,6 +281,10 @@ const config: ForgeConfig = {
         },
     ],
     hooks: {
+        // 在 asar 打包前裁掉异平台/异架构原生库（同时避免 Linux RPM 的 brp-strip 失败）
+        packageAfterCopy: async (_forgeConfig, buildPath, _electronVersion, platform, arch) => {
+            await pruneForeignNativeVariants(buildPath, platform, arch);
+        },
         postMake: async (_forgeConfig, makeResults) => {
             const version = packageJson.version;
             for (const result of makeResults) {


### PR DESCRIPTION
## 背景

已发布的 `v6.11.0` 预发布包（mac/win）装上就崩，两个连续的启动崩溃，加上一个 Linux 发版阻塞项，共三个独立问题：

1. **scoped 依赖整体丢包**：`forge.config.ts` 的白名单只列了 `/node_modules/@huggingface/transformers` 这类包路径，没列父目录 `/node_modules/@huggingface`。而 electron-packager 的 `ignore` 返回 `true` 时会**连整棵子树一起跳过**，于是 `@huggingface/*`、`@img/*`（sharp 原生库）、`@protobufjs/*`、`@isaacs/*`、`@types/*` 全部没进包。主进程 bundle 里 `require('@huggingface/transformers')` 是 Vite 显式 external 的，启动即 `Cannot find module '@huggingface/transformers'`。
2. **原生动态库没解包**：`asar.unpack` 只解 `.wasm`/`.node`，`onnxruntime_binding.node` 解出来了，但它依赖的 `libonnxruntime.1.21.0.dylib` 还留在 `app.asar` 内部——dyld/ld.so 读不了 asar，于是 `Library not loaded: @rpath/libonnxruntime.1.21.0.dylib`（sharp 的 libvips 同理）。
3. **Linux RPM 打包失败**：x64 包里带了 `onnxruntime-node` 的 aarch64 预编译库，rpmbuild 的 `brp-strip` 用宿主 strip 处理它时报 `Unable to recognise the format`，`%install` bad exit → 整个 linux 构建红。

## 改动（3 个 commit）

- `598fba1a` fix: 白名单除路径自身外，放行其所有祖先目录（兼容 `/node_modules/@img/` 这种带结尾斜杠的写法）。
- `63656512` fix: `asar.unpack` 增加 `dylib`、`so`、`so.*`（Linux 是 `libonnxruntime.so.1` / `.so.1.21.0`，`*.so` 匹配不到）。
- `920a6f79` build: 新增 `packageAfterCopy` 钩子，在 asar 打包前按目标 platform/arch 裁掉原生库变体：`onnxruntime-node/bin/napi-v3/<platform>/<arch>`、`@img/sharp-<platform>-<arch>`（`@img/colour` 等平台无关包不受影响）、`better-sqlite3/bin/<platform>-<arch>-<abi>`。顺带解决异架构 ELF 让 RPM 失败的问题，并给每个平台产物瘦身。

## 验证

- `npx electron-forge package --platform=darwin --arch=arm64`：日志打印 `[prune-native] 移除 node_modules/onnxruntime-node/bin/napi-v3/{darwin/x64,linux,win32}`；产物内可见 `node_modules/@huggingface/transformers/package.json` 等 scoped 包，`app.asar.unpacked` 内是 `onnxruntime_binding.node` + 同目录 `libonnxruntime.1.21.0.dylib` + sharp libvips；**用临时 `--user-data-dir` 启动打包产物进程存活、日志无 Uncaught Exception**（修复前两处都是启动即崩）；app 体积 1.0G → 847M。
- 对 `linux/x64` 干跑同一裁剪规则：保留的原生库全部是 x86-64 ELF，不再有 aarch64 残留 → RPM `brp-strip` 不会再失败。
- 静态核对主进程 bundle 的运行时 `require`：`@huggingface/transformers`、`better-sqlite3`、`undici`、`fetch-socks`、`ipaddr.js` 均可在包内解析。

无 UI 流程变化、无 drizzle 迁移、无需重新执行 `yarn run download`。

## 发版提示

`v6.11.0` 预发布包的 mac/win 产物是坏的，合并后 release-please 会出 6.11.1，四平台构建成功再对外发。
