### PR TITLE
ci: whisper 运行时改用运行内产物传递，发版资产在 app 构建成功后统一上传

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,6 @@ jobs:
   release-please:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      # 透传发版 tag。steps 上下文只在 job outputs 处可用，下游 job 的
-      # with 里必须经 needs 引用本 output，直接写 steps.* 会导致整个
-      # workflow 文件解析失败（Unrecognized named-value）。
-      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
@@ -32,11 +28,10 @@ jobs:
 
   # 发版 PR 合并（release_created 为 true）时，直接调用 release.yml 执行四平台构建；
   # 构建上下文即本次 push 的 main 提交（发版 PR 的合并结果，与 tag 内容一致）。
+  # 安装包由 electron-forge publish 按 package.json 版本号自行挂到对应 Release，无需传 tag
   build:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
-    with:
-      release_tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,6 @@ on:
   # （GITHUB_TOKEN 打的 tag 不会触发 push 事件，不能只靠下面的 tag 触发器）
   workflow_call:
     inputs:
-      # 发版 tag（如 v6.12.0）。workflow_call 上下文是 main 分支 push，
-      # 取不到 tag 名，由 release-please 显式传入，供运行时资产上传到对应 Release
-      release_tag:
-        type: string
-        required: false
-        default: ''
       # 与 workflow_dispatch 的同名开关一致；发版链路固定不传（false）
       runtime_only:
         type: boolean
@@ -42,10 +36,11 @@ permissions:
   contents: write
 jobs:
   # whisper.cpp 核显运行时先行构建，作为本次运行的临时产物（artifact）交给 app 构建，
-  # 由 download.mjs 从 DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装——不再“先挂 Release 再下载”。
+  # 由 download.mjs 从 DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装。运行时不上传 Release：
+  # 发版资产只放安装包，开发机需要运行时就走 download.mjs 的本地源码编译。
   # 矩阵 fail-fast: false：单个目标失败不阻塞其余目标，也不阻塞其他平台的 app 构建；
   # 但缺了自家平台运行时的平台会构建失败（download.mjs 在 CI 下不编译兜底、不静默跳过），
-  # 避免发出一个默认识别引擎不可用的包。挂到 Release 由末尾的 publish-runtime 统一做
+  # 避免发出一个默认识别引擎不可用的包
   whisper-cpp-runtime:
     strategy:
       fail-fast: false
@@ -106,7 +101,7 @@ jobs:
         run: cmake --build build --config Release --target parakeet-cli -j 4
       - name: Package
         # 资产名契约：scripts/download.mjs 的 whisperRuntimeAssetName() 按同一套
-        # whisper-cpp-<platform>-<arch>.{tar.gz,zip} 规则拼下载地址，改名必须两边同步
+        # whisper-cpp-<platform>-<arch>.{tar.gz,zip} 规则去临时产物目录里找归档，改名必须两边同步
         shell: bash
         run: |
           mkdir -p stage
@@ -128,7 +123,7 @@ jobs:
           retention-days: 7
   build:
     # needs 只为保证运行内产物先产出再被下载（download.mjs 从
-    # DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装，不再依赖 Release 资产）；
+    # DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装，运行时不经过 Release）；
     # 配合 !cancelled() 让运行时任务失败时其余平台照常构建（缺自家平台运行时的那一平台
     # 会在安装步骤显式失败）；runtime_only 给手动干跑用，理由同上
     needs: whisper-cpp-runtime
@@ -197,27 +192,3 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
           DASHPLAYER_WHISPER_RUNTIME_DIR: ${{ github.workspace }}\.ci-runtime
         run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 && npm run ${{ inputs.package_only && 'make' || 'publish' }}
-
-  # 运行内产物用完后再挂到 Release：本地开发 `yarn run download` 从 Release 取资产，
-  # 而这里等 app 构建全部成功才上传，避免出现“Release 上只有运行时、没有安装包”的半成品
-  publish-runtime:
-    needs: [whisper-cpp-runtime, build]
-    if: ${{ success() && !inputs.runtime_only && !inputs.package_only && (inputs.release_tag != '' || github.ref_type == 'tag') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download runtime artifacts
-        uses: actions/download-artifact@v8
-        with:
-          pattern: whisper-runtime-*
-          path: runtime
-          merge-multiple: true
-      - name: Upload to release
-        # workflow_call 链路用传入的 release_tag；tag push 链路用当前 ref
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          TAG="${{ inputs.release_tag || github.ref_name }}"
-          ls -l runtime
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
-          gh release upload "$TAG" runtime/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       # 只构建 whisper.cpp 运行时矩阵、跳过 app 构建：用于发版前干跑验证
-      # Vulkan/Metal 工具链。手动触发时运行时任务本身也跳过上传，不碰 Release 资产
+      # Vulkan/Metal 工具链。app 构建会 publish 到当前版本的已发布 Release，
+      # 所以只验运行时矩阵时必须能整体跳过它
       runtime_only:
+        type: boolean
+        required: false
+        default: false
+      # 只打包不上传（electron-forge make，而非 publish）：用于在分支上验证完整
+      # 打包链路（含运行内产物注入的 whisper 运行时），不碰 Release
+      package_only:
         type: boolean
         required: false
         default: false
@@ -24,15 +31,21 @@ on:
         type: boolean
         required: false
         default: false
+      # 同上：发版链路固定不传（false），只给手动干跑用
+      package_only:
+        type: boolean
+        required: false
+        default: false
   push:
     tags: ['v*']
 permissions:
   contents: write
 jobs:
-  # whisper.cpp 核显运行时先行构建并挂到 Release，供后续 publish 中的
-  # `yarn run download` 取用。矩阵 fail-fast: false：单个目标失败不阻塞其余目标，
-  # 也不阻塞其他平台的 app 构建；但缺了自家平台资产的平台会构建失败
-  # （download.mjs 在 CI 下不编译兜底、不静默跳过），避免发出一个默认识别引擎不可用的包
+  # whisper.cpp 核显运行时先行构建，作为本次运行的临时产物（artifact）交给 app 构建，
+  # 由 download.mjs 从 DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装——不再“先挂 Release 再下载”。
+  # 矩阵 fail-fast: false：单个目标失败不阻塞其余目标，也不阻塞其他平台的 app 构建；
+  # 但缺了自家平台运行时的平台会构建失败（download.mjs 在 CI 下不编译兜底、不静默跳过），
+  # 避免发出一个默认识别引擎不可用的包。挂到 Release 由末尾的 publish-runtime 统一做
   whisper-cpp-runtime:
     strategy:
       fail-fast: false
@@ -104,27 +117,20 @@ jobs:
             cp build/bin/parakeet-cli stage/parakeet-cli
             (cd stage && tar czf "../whisper-cpp-${{ matrix.name }}.tar.gz" parakeet-cli)
           fi
-      - name: Upload to release
-        # workflow_call 链路用传入的 release_tag；tag push 链路用当前 ref。
-        # 手动触发（无 tag、无发版）时仅验证构建，不上传
-        if: inputs.release_tag != '' || github.ref_type == 'tag'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          TAG="${{ inputs.release_tag || github.ref_name }}"
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            ASSET="whisper-cpp-${{ matrix.name }}.zip"
-          else
-            ASSET="whisper-cpp-${{ matrix.name }}.tar.gz"
-          fi
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
-          gh release upload "$TAG" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber
+      - name: Upload runtime artifact
+        # 只留在本次运行内：app 构建要的就是同一份二进制，直接递过去，
+        # 既不用等 Release 先存在，也不会在构建失败时留下“有运行时、没安装包”的半成品 Release
+        uses: actions/upload-artifact@v7
+        with:
+          name: whisper-runtime-${{ matrix.name }}
+          path: whisper-cpp-${{ matrix.name }}.*
+          if-no-files-found: error
+          retention-days: 7
   build:
-    # needs 只为保证运行时资产先上传再被 yarn run download 拉取；
-    # 配合 !cancelled() 让运行时任务失败时其余平台照常构建；
-    # runtime_only 给手动干跑用：app 构建会 electron-forge publish 到当前版本的已发布
-    # Release，所以只验运行时矩阵时必须能整体跳过它
+    # needs 只为保证运行内产物先产出再被下载（download.mjs 从
+    # DASHPLAYER_WHISPER_RUNTIME_DIR 就地安装，不再依赖 Release 资产）；
+    # 配合 !cancelled() 让运行时任务失败时其余平台照常构建（缺自家平台运行时的那一平台
+    # 会在安装步骤显式失败）；runtime_only 给手动干跑用，理由同上
     needs: whisper-cpp-runtime
     if: ${{ !cancelled() && !inputs.runtime_only }}
     strategy:
@@ -164,17 +170,54 @@ jobs:
         if: matrix.os.name == 'windows'
         shell: cmd
         run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 && yarn install --frozen-lockfile
+      - name: Download whisper runtime artifacts
+        # 某个平台运行时没构建出来时不在这里报错：下载不到与产物缺失都会落到
+        # download.mjs 的安装步骤，由它在 CI 下带原因显式失败
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: whisper-runtime-*
+          path: .ci-runtime
+          merge-multiple: true
       - name: Publish app
         if: matrix.os.name != 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 主进程 bundle 已大过 V8 默认 ~2GB 堆上限，构建时 OOM（v6.7.0 arm64 dmg 缺失的直接原因）
           NODE_OPTIONS: --max-old-space-size=4096
-        run: npm run publish
+          # 运行时由本次运行的产物提供，download.mjs 直接就地安装
+          DASHPLAYER_WHISPER_RUNTIME_DIR: ${{ github.workspace }}/.ci-runtime
+        # package_only：只跑 make 验证打包，不做 GitHub 发布
+        run: npm run ${{ inputs.package_only && 'make' || 'publish' }}
       - name: Publish app with Visual Studio (Windows only)
         if: matrix.os.name == 'windows'
         shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=4096
-        run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 && npm run publish
+          DASHPLAYER_WHISPER_RUNTIME_DIR: ${{ github.workspace }}\.ci-runtime
+        run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 && npm run ${{ inputs.package_only && 'make' || 'publish' }}
+
+  # 运行内产物用完后再挂到 Release：本地开发 `yarn run download` 从 Release 取资产，
+  # 而这里等 app 构建全部成功才上传，避免出现“Release 上只有运行时、没有安装包”的半成品
+  publish-runtime:
+    needs: [whisper-cpp-runtime, build]
+    if: ${{ success() && !inputs.runtime_only && !inputs.package_only && (inputs.release_tag != '' || github.ref_type == 'tag') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: whisper-runtime-*
+          path: runtime
+          merge-multiple: true
+      - name: Upload to release
+        # workflow_call 链路用传入的 release_tag；tag push 链路用当前 ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          TAG="${{ inputs.release_tag || github.ref_name }}"
+          ls -l runtime
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          gh release upload "$TAG" runtime/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -602,13 +602,13 @@ const whisperRuntimeAssetName = (platform, arch) =>
     `whisper-cpp-${platform}-${arch}.${platform === 'win32' ? 'zip' : 'tar.gz'}`;
 
 /**
- * 本地源码构建 whisper.cpp parakeet-cli（发布资产不可用时的开发机兜底）。
+ * 本地源码构建 whisper.cpp parakeet-cli（开发机获取运行时的唯一路径）。
  *
  * 复刻 release.yml whisper-cpp-runtime 任务的构建参数：静态链接
  * （BUILD_SHARED_LIBS=OFF），macOS Metal 内嵌 GGML 库
  * （GGML_METAL_EMBED_LIBRARY=ON），产出单文件自包含二进制。
  * 源码缓存在 node_modules/.cache/whisper.cpp（不随应用打包，也不进 git）。
- * 只在开发机调用：CI 上缺资产是发版流水线的问题，必须显式失败（见下方 whisper.cpp 段落）。
+ * 只在开发机调用：CI 侧由 release.yml 的 whisper-cpp-runtime 任务提供预编译产物。
  *
  * @param {{ basePath: string, exeName: string }} param 目标目录与可执行文件名。
  * @returns {Promise<boolean>} 构建成功且二进制已就位时 true；缺少构建依赖或构建失败时
@@ -721,12 +721,11 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
 
 {
     // whisper.cpp 离线识别 CLI（whisper.cpp 引擎的核显加速运行时）。
-    // 二进制跟着安装包一起分发，来源有两个：
+    // 二进制跟着安装包一起分发，来源只有两个：
     //   1) DASHPLAYER_WHISPER_RUNTIME_DIR 指定目录里已有归档：release.yml 的
-    //      whisper-cpp-runtime 任务构建出的产物在本次运行内直接传给 app 构建
-    //      （不再“先上传 Release 再下载”），本地也可手动指定跳过网络；
-    //   2) 当前版本对应的 Release 资产：本地开发的默认路径，发版时由
-    //      release.yml 的 publish-runtime 任务在 app 构建全部成功后挂上去。
+    //      whisper-cpp-runtime 任务构建出的产物在本次运行内直接传给 app 构建；
+    //   2) 其余情况（开发机）：按固定 ref 本地编译源码（buildWhisperCppFromSource）。
+    // 运行时不上传 Release：发版资产只放安装包。
     const platformDir = platform === 'darwin' ? 'darwin' : platform === 'win32' ? 'win32' : 'linux';
     const archDir = arch === 'arm64' ? 'arm64' : 'x64';
     const basePath = path.join(dir, 'whisper-cpp', archDir, platformDir);
@@ -741,37 +740,18 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
     if (!supportedArchs[platform]?.includes(arch)) {
         console.info(chalk.yellow(`=> whisper.cpp 暂不提供 ${platform}/${arch} 运行时，已跳过；whisper.cpp 引擎在该平台不可用，请使用 sherpa-onnx 引擎`));
     } else {
-        const version = packageJson.version;
-        const assetUrl = `https://github.com/solidSpoon/DashPlayer/releases/download/v${version}/${whisperRuntimeAssetName(platform, arch)}`;
-        // CI 会用这个变量把本次运行的运行时产物目录传进来；有本地归档就不再探 Release
+        // CI 会把本次运行的运行时产物目录传进来（release.yml 的 whisper-cpp-runtime
+        // 任务产出 artifact，再由 app 构建任务下载到该目录）
         const localArchiveDir = process.env.DASHPLAYER_WHISPER_RUNTIME_DIR;
         const localArchivePath = localArchiveDir
             ? path.join(localArchiveDir, whisperRuntimeAssetName(platform, arch))
             : null;
         const localArchiveExists = Boolean(localArchivePath && fs.existsSync(localArchivePath));
-        // 预检 Release 资产是否存在：download() 对任何失败都会终止整个脚本，
-        // 而资产缺失（本地开发、历史版本）是可跳过的合法状态，只对 404 放行跳过。
-        // 必须带超时：无超时的 axios 在 GitHub 偶发挂起时会让整个脚本静默卡死
-        let assetExists = false;
-        if (!localArchiveExists) {
-            assetExists = true;
-            try {
-                await axios.head(assetUrl, { headers: getGithubAuthHeaders(assetUrl), timeout: 15000 });
-            } catch (error) {
-                if (error?.response?.status === 404) {
-                    assetExists = false;
-                } else {
-                    // 非 404（网络/超时）：资产是否存在还未知，按“存在”继续，
-                    // 真有问题会在下面的下载步骤报错退出，不在这里静默掉
-                    console.info(chalk.yellow(`=> whisper.cpp 资产预检未完成（${error.message}），继续尝试下载`));
-                }
-            }
-        }
 
         // parakeet-cli 的输出格式是解析契约（见 WhisperCppCli.parseOutput），所以已装的
-        // 二进制必须带上来源：标记与预期不符（换版本 / 换 ref / 手工放置）就重新安装。
-        // 本地归档同样来自固定 ref 的源码构建，因此与源码兜底共用 source 标记。
-        const expectedMarker = assetExists ? `release:${version}` : `source:${WHISPER_CPP_REF}`;
+        // 二进制必须带上来源：标记与预期不符（换了 whisper.cpp ref / 手工放置）就重新安装。
+        // 运行时只由固定 ref 的源码构建产出，因此标记统一是 source:<ref>。
+        const expectedMarker = `source:${WHISPER_CPP_REF}`;
         const installedMarker = readWhisperRuntimeMarker(markerPath);
         if (fs.existsSync(exePath) && installedMarker === expectedMarker) {
             console.info(chalk.green(`✅ File ${exeName} already exists (${expectedMarker})`));
@@ -788,27 +768,19 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
                     binaryNameCandidates: ['parakeet-cli', 'parakeet-cli.exe'],
                 });
                 fs.writeFileSync(markerPath, `${expectedMarker}\n`);
-            } else if (assetExists) {
-                console.info(chalk.blue(`=> whisper.cpp target: ${exePath}`));
-                await downloadAndExtractBinaryFromArchive({
-                    url: assetUrl,
-                    outputPath: exePath,
-                    binaryNameCandidates: ['parakeet-cli', 'parakeet-cli.exe'],
-                });
-                fs.writeFileSync(markerPath, `${expectedMarker}\n`);
             } else if (process.env.CI) {
-                // CI 上不许编译兜底：缺资产说明 whisper-cpp-runtime 没产出该平台运行时，
+                // CI 上不许编译兜底：缺运行时说明 whisper-cpp-runtime 没产出该平台产物，
                 // 而 whisper.cpp 是新用户的默认识别引擎，必须让该平台构建显式失败
                 console.error(
                     chalk.red(
-                        `❌ whisper.cpp 运行时缺失：${assetUrl}\n` +
-                        `   CI 走运行内产物时应由 DASHPLAYER_WHISPER_RUNTIME_DIR 提供归档（当前：${localArchivePath ?? '未设置'}）\n` +
+                        `❌ whisper.cpp 运行时缺失：CI 应从 DASHPLAYER_WHISPER_RUNTIME_DIR 取得归档\n` +
+                        `   期望路径：${localArchivePath ?? '（变量未设置）'}\n` +
                         `   请检查 release.yml 的 whisper-cpp-runtime 任务是否成功构建了 ${platform}/${arch} 运行时。`
                     )
                 );
                 process.exit(1);
             } else {
-                // 开发机（尚未发版 / checkout 历史版本）：回退到本地源码构建
+                // 开发机：没有预编译产物，回退到本地源码编译（缺工具链时上面已有安装提示）
                 const built = await buildWhisperCppFromSource({ basePath, exeName });
                 if (built) {
                     fs.writeFileSync(markerPath, `${expectedMarker}\n`);

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -11,6 +11,7 @@ import * as tarFs from 'tar-fs';
 import unbzip2Stream from 'unbzip2-stream';
 import chalk from 'chalk';
 import { $ } from 'zx';
+import { withNetworkRetry } from './network-retry.mjs';
 
 const getGithubToken = () => process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
@@ -152,13 +153,13 @@ const downloadAndExtractBinaryFromZip = async ({url, outputPath, binaryNameCandi
 
 const getLatestReleaseAssetUrl = async ({owner, repo, nameRegex}) => {
     const apiUrl = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
-    const res = await axios.get(apiUrl, {
+    const res = await withNetworkRetry(() => axios.get(apiUrl, {
         headers: {
             'Accept': 'application/vnd.github+json',
             'User-Agent': 'DashPlayer-downloader',
             ...getGithubAuthHeaders(apiUrl),
         }
-    });
+    }), {label: `查询 ${owner}/${repo} 最新发布`});
     const assets = res.data?.assets ?? [];
     const match = assets.find((a) => nameRegex.test(a?.name || ''));
     return match?.browser_download_url || null;
@@ -166,13 +167,13 @@ const getLatestReleaseAssetUrl = async ({owner, repo, nameRegex}) => {
 
 const getLatestReleaseAssetUrlIncludingPrerelease = async ({owner, repo, nameRegex}) => {
     const apiUrl = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=10`;
-    const res = await axios.get(apiUrl, {
+    const res = await withNetworkRetry(() => axios.get(apiUrl, {
         headers: {
             'Accept': 'application/vnd.github+json',
             'User-Agent': 'DashPlayer-downloader',
             ...getGithubAuthHeaders(apiUrl),
         }
-    });
+    }), {label: `查询 ${owner}/${repo} 发布列表`});
     const releases = res.data ?? [];
     for (const release of releases) {
         const assets = release?.assets ?? [];
@@ -511,7 +512,49 @@ function setProxy() {
 }
 
 /**
+ * 单次下载尝试：流式写入目标文件，并按需校验 SHA1。
+ * 失败时抛出错误，交给 withNetworkRetry 判断是否值得重试。
+ *
+ * @param {{url: string, dest: string, file: string, sha: string | undefined}} param
+ *   url 下载地址；dest 目标文件路径；file 文件名（日志与校验用）；sha 可选 SHA1。
+ * @returns {Promise<void>} 文件写入并通过校验后结束。
+ */
+async function fetchToFile({url, dest, file, sha}) {
+    const response = await axios.get(url, {
+        responseType: "stream",
+        headers: getGithubAuthHeaders(url),
+    });
+    const totalLength = response.headers["content-length"];
+
+    const progressBar = new progress(`-> downloading [:bar] :percent :etas`, {
+        width: 40,
+        complete: "=",
+        incomplete: " ",
+        renderThrottle: 1,
+        total: parseInt(totalLength),
+    });
+
+    response.data.on("data", (chunk) => {
+        progressBar.tick(chunk.length);
+    });
+    await new Promise((resolve, reject) => {
+        response.data.pipe(fs.createWriteStream(dest)).on("close", async () => {
+            console.info(chalk.green(`✅ File ${file} downloaded successfully`));
+            const hash = await hashFile(dest, {algo: "sha1"});
+            if (sha === undefined || hash === sha) {
+                resolve();
+            } else {
+                // 内容对不上：常见原因是下载被截断，带 HASH_MISMATCH 让上层重下一次
+                reject(Object.assign(new Error(`File ${file} sha1 mismatch`), {code: 'HASH_MISMATCH'}));
+            }
+        });
+    });
+}
+
+/**
  * 下载文件并校验可选的 SHA1 摘要。
+ * 瞬时网络故障（DNS 抖动、连接重置、5xx、下载被截断）会退避重试，重试用尽才失败。
+ *
  * @param url {string} 下载地址。
  * @param dir {string} 保存目录。
  * @param file {string} 保存文件名。
@@ -522,40 +565,8 @@ async function download({url, dir, file, sha}) {
     const dest = path.join(dir, file);
     console.info(chalk.blue(`=> Start to download from ${url} to ${dest}`));
     try {
-        const response = await axios.get(url, {
-            responseType: "stream",
-            headers: getGithubAuthHeaders(url),
-        });
-        const totalLength = response.headers["content-length"];
-
-        const progressBar = new progress(`-> downloading [:bar] :percent :etas`, {
-            width: 40,
-            complete: "=",
-            incomplete: " ",
-            renderThrottle: 1,
-            total: parseInt(totalLength),
-        });
-
-        response.data.on("data", (chunk) => {
-            progressBar.tick(chunk.length);
-        });
-        await new Promise((resolve, reject) => {
-            response.data.pipe(fs.createWriteStream(dest)).on("close", async () => {
-                console.info(chalk.green(`✅ File ${file} downloaded successfully`));
-                const hash = await hashFile(path.join(dir, file), {algo: "sha1"});
-                if (sha === undefined || hash === sha) {
-                    console.info(chalk.green(`✅ File ${file} valid`));
-                    resolve();
-                } else {
-                    console.error(
-                        chalk.red(
-                            `❌ File ${file} not valid, please try again using command \`yarn download\``
-                        )
-                    );
-                    reject();
-                }
-            });
-        });
+        await withNetworkRetry(() => fetchToFile({url, dest, file, sha}), {label: `download ${file}`});
+        console.info(chalk.green(`✅ File ${file} valid`));
     } catch (err) {
         console.error(
             chalk.red(

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -182,19 +182,17 @@ const getLatestReleaseAssetUrlIncludingPrerelease = async ({owner, repo, nameReg
     return null;
 };
 
-const downloadAndExtractBinaryFromArchive = async ({
-    url,
-    outputPath,
-    binaryNameCandidates,
-    extraCopyPatterns = [],
-}) => {
-    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dashplayer-download-'));
-    const nameFromUrl = String(url).split('/').pop() || 'asset';
-    const archivePath = path.join(tmpRoot, nameFromUrl);
-    console.info(chalk.blue(`=> runtime archive: ${url}`));
-    await download({url, dir: tmpRoot, file: nameFromUrl});
-
-    const extractDir = path.join(tmpRoot, 'extract');
+/**
+ * 把归档里的运行时二进制安装到目标路径（下载得到的归档与本地已有归档共用）。
+ *
+ * @param {{ archivePath: string, outputPath: string, binaryNameCandidates: string[], extraCopyPatterns?: RegExp[] }} param
+ *   archivePath 归档文件路径（.tar.gz / .zip / .tar.bz2）；outputPath 二进制目标路径；
+ *   binaryNameCandidates 归档里可接受的二进制文件名；extraCopyPatterns 需要一并拷到目标目录的附加文件。
+ * @returns {Promise<void>}
+ */
+const installBinaryFromArchive = async ({archivePath, outputPath, binaryNameCandidates, extraCopyPatterns = []}) => {
+    const tmpRoot = path.dirname(archivePath);
+    const extractDir = path.join(tmpRoot, `extract-${path.basename(archivePath)}`);
     await extractArchive(archivePath, extractDir);
 
     const found = findFirstFile(
@@ -203,7 +201,7 @@ const downloadAndExtractBinaryFromArchive = async ({
         12
     );
     if (!found) {
-        throw new Error(`Cannot find binary in archive from ${url}`);
+        throw new Error(`Cannot find binary in archive ${archivePath}`);
     }
 
     mkdirp(path.dirname(outputPath));
@@ -237,6 +235,27 @@ const downloadAndExtractBinaryFromArchive = async ({
             }
         }
     }
+};
+
+/**
+ * 从 URL 下载归档并安装运行时二进制。
+ *
+ * @param {{ url: string, outputPath: string, binaryNameCandidates: string[], extraCopyPatterns?: RegExp[] }} param
+ *   url 归档地址；其余参数同 installBinaryFromArchive。
+ * @returns {Promise<void>}
+ */
+const downloadAndExtractBinaryFromArchive = async ({
+    url,
+    outputPath,
+    binaryNameCandidates,
+    extraCopyPatterns = [],
+}) => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dashplayer-download-'));
+    const nameFromUrl = String(url).split('/').pop() || 'asset';
+    const archivePath = path.join(tmpRoot, nameFromUrl);
+    console.info(chalk.blue(`=> runtime archive: ${url}`));
+    await download({url, dir: tmpRoot, file: nameFromUrl});
+    await installBinaryFromArchive({archivePath, outputPath, binaryNameCandidates, extraCopyPatterns});
 };
 
 /**
@@ -702,8 +721,12 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
 
 {
     // whisper.cpp 离线识别 CLI（whisper.cpp 引擎的核显加速运行时）。
-    // 资产随应用 Release 一起发布：release.yml 的 whisper-cpp-runtime 任务
-    // 在发版时构建四个目标并上传；本段从当前版本对应的 Release 下载。
+    // 二进制跟着安装包一起分发，来源有两个：
+    //   1) DASHPLAYER_WHISPER_RUNTIME_DIR 指定目录里已有归档：release.yml 的
+    //      whisper-cpp-runtime 任务构建出的产物在本次运行内直接传给 app 构建
+    //      （不再“先上传 Release 再下载”），本地也可手动指定跳过网络；
+    //   2) 当前版本对应的 Release 资产：本地开发的默认路径，发版时由
+    //      release.yml 的 publish-runtime 任务在 app 构建全部成功后挂上去。
     const platformDir = platform === 'darwin' ? 'darwin' : platform === 'win32' ? 'win32' : 'linux';
     const archDir = arch === 'arm64' ? 'arm64' : 'x64';
     const basePath = path.join(dir, 'whisper-cpp', archDir, platformDir);
@@ -720,24 +743,34 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
     } else {
         const version = packageJson.version;
         const assetUrl = `https://github.com/solidSpoon/DashPlayer/releases/download/v${version}/${whisperRuntimeAssetName(platform, arch)}`;
-        // 预检资产是否存在：download() 对任何失败都会终止整个脚本，
+        // CI 会用这个变量把本次运行的运行时产物目录传进来；有本地归档就不再探 Release
+        const localArchiveDir = process.env.DASHPLAYER_WHISPER_RUNTIME_DIR;
+        const localArchivePath = localArchiveDir
+            ? path.join(localArchiveDir, whisperRuntimeAssetName(platform, arch))
+            : null;
+        const localArchiveExists = Boolean(localArchivePath && fs.existsSync(localArchivePath));
+        // 预检 Release 资产是否存在：download() 对任何失败都会终止整个脚本，
         // 而资产缺失（本地开发、历史版本）是可跳过的合法状态，只对 404 放行跳过。
         // 必须带超时：无超时的 axios 在 GitHub 偶发挂起时会让整个脚本静默卡死
-        let assetExists = true;
-        try {
-            await axios.head(assetUrl, { headers: getGithubAuthHeaders(assetUrl), timeout: 15000 });
-        } catch (error) {
-            if (error?.response?.status === 404) {
-                assetExists = false;
-            } else {
-                // 非 404（网络/超时）：资产是否存在还未知，按“存在”继续，
-                // 真有问题会在下面的下载步骤报错退出，不在这里静默掉
-                console.info(chalk.yellow(`=> whisper.cpp 资产预检未完成（${error.message}），继续尝试下载`));
+        let assetExists = false;
+        if (!localArchiveExists) {
+            assetExists = true;
+            try {
+                await axios.head(assetUrl, { headers: getGithubAuthHeaders(assetUrl), timeout: 15000 });
+            } catch (error) {
+                if (error?.response?.status === 404) {
+                    assetExists = false;
+                } else {
+                    // 非 404（网络/超时）：资产是否存在还未知，按“存在”继续，
+                    // 真有问题会在下面的下载步骤报错退出，不在这里静默掉
+                    console.info(chalk.yellow(`=> whisper.cpp 资产预检未完成（${error.message}），继续尝试下载`));
+                }
             }
         }
 
         // parakeet-cli 的输出格式是解析契约（见 WhisperCppCli.parseOutput），所以已装的
-        // 二进制必须带上来源：标记与预期不符（换版本 / 换 ref / 手工放置）就重新安装
+        // 二进制必须带上来源：标记与预期不符（换版本 / 换 ref / 手工放置）就重新安装。
+        // 本地归档同样来自固定 ref 的源码构建，因此与源码兜底共用 source 标记。
         const expectedMarker = assetExists ? `release:${version}` : `source:${WHISPER_CPP_REF}`;
         const installedMarker = readWhisperRuntimeMarker(markerPath);
         if (fs.existsSync(exePath) && installedMarker === expectedMarker) {
@@ -746,7 +779,16 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
             if (fs.existsSync(exePath) && installedMarker === null) {
                 console.info(chalk.yellow(`=> 现有 ${exeName} 没有来源标记（手工放置或旧版本安装），按 ${expectedMarker} 重新安装以对齐版本`));
             }
-            if (assetExists) {
+            if (localArchiveExists) {
+                console.info(chalk.blue(`=> whisper.cpp target: ${exePath}`));
+                console.info(chalk.blue(`=> whisper.cpp 使用本地运行归档：${localArchivePath}`));
+                await installBinaryFromArchive({
+                    archivePath: localArchivePath,
+                    outputPath: exePath,
+                    binaryNameCandidates: ['parakeet-cli', 'parakeet-cli.exe'],
+                });
+                fs.writeFileSync(markerPath, `${expectedMarker}\n`);
+            } else if (assetExists) {
                 console.info(chalk.blue(`=> whisper.cpp target: ${exePath}`));
                 await downloadAndExtractBinaryFromArchive({
                     url: assetUrl,
@@ -759,8 +801,9 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
                 // 而 whisper.cpp 是新用户的默认识别引擎，必须让该平台构建显式失败
                 console.error(
                     chalk.red(
-                        `❌ whisper.cpp 运行时资产缺失：${assetUrl}\n` +
-                        `   请检查 release.yml 的 whisper-cpp-runtime 任务是否成功构建并上传了 ${platform}/${arch} 运行时。`
+                        `❌ whisper.cpp 运行时缺失：${assetUrl}\n` +
+                        `   CI 走运行内产物时应由 DASHPLAYER_WHISPER_RUNTIME_DIR 提供归档（当前：${localArchivePath ?? '未设置'}）\n` +
+                        `   请检查 release.yml 的 whisper-cpp-runtime 任务是否成功构建了 ${platform}/${arch} 运行时。`
                     )
                 );
                 process.exit(1);

--- a/scripts/network-retry.mjs
+++ b/scripts/network-retry.mjs
@@ -1,0 +1,62 @@
+/**
+ * 网络抖动重试：发版链路上的资产下载（ffmpeg / whisper.cpp 运行时 / GitHub API 查询）
+ * 依赖不少第三方站点，一次 DNS 抖动或 5xx 就会让整个发版失败，
+ * 而这类错误重试一次基本就能过。
+ */
+
+/** 值得重试的错误码：DNS 解析失败、连接被重置/超时、连接被拒等瞬时网络故障。 */
+const RETRYABLE_ERROR_CODES = new Set([
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ECONNABORTED',
+    'ETIMEDOUT',
+    'EPIPE',
+    'ERR_NETWORK',
+    // 流式下载被截断：内容长度与 sha1 对不上，重下一次通常就好了
+    'HASH_MISMATCH',
+]);
+
+/**
+ * 判断一个错误是否值得重试。
+ *
+ * @param {unknown} error 抛出的错误对象（axios 错误带 code / response）。
+ * @returns {boolean} 瞬时故障返回 true；404 这类确定性失败返回 false（重试也没用）。
+ */
+export const isRetryableNetworkError = (error) => {
+    const code = error && typeof error === 'object' ? error.code : undefined;
+    if (typeof code === 'string' && RETRYABLE_ERROR_CODES.has(code)) {
+        return true;
+    }
+    const status = error && typeof error === 'object' ? error.response?.status : undefined;
+    return typeof status === 'number' && (status === 429 || status >= 500);
+};
+
+/**
+ * 执行网络任务，遇到瞬时故障按指数退避重试。
+ *
+ * @param {() => Promise<T>} task 实际发起网络请求的任务；每次重试都会重新调用。
+ * @param {{ label?: string, attempts?: number, baseDelayMs?: number, onRetry?: (error: unknown) => void }} [options]
+ *   label 日志前缀；attempts 总尝试次数（含首次）；baseDelayMs 首次退避时长，之后翻倍。
+ * @returns {Promise<T>} 任务结果。
+ * @throws 超出重试次数或遇到不可重试错误时，抛出最后一次的错误。
+ * @template T
+ */
+export const withNetworkRetry = async (task, {label = '网络请求', attempts = 3, baseDelayMs = 2000, onRetry} = {}) => {
+    for (let attempt = 1; ; attempt += 1) {
+        try {
+            return await task();
+        } catch (error) {
+            if (attempt >= attempts || !isRetryableNetworkError(error)) {
+                throw error;
+            }
+            const delayMs = baseDelayMs * 2 ** (attempt - 1);
+            onRetry?.(error);
+            console.warn(
+                `=> ${label} 失败（${error?.code || error?.message || error}），${delayMs / 1000}s 后重试（第 ${attempt + 1}/${attempts} 次）`
+            );
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+    }
+};


### PR DESCRIPTION
## 背景

whisper 运行时原来走「运行时任务先上传到 Release → app 构建再从 Release 下载」：绕一圈网络，任一步失败还会在 Releases 页面上留下「只有运行时、没有安装包」的半成品（v6.11.0 就是这状态）；那些 `whisper-cpp-*.tar.gz` 对用户也没有任何意义。

另外发 6.11.1 时 macos-x64 挂在下载 ffmpeg（`getaddrinfo ENOTFOUND ffmpeg.martin-riedl.de`，同一 run 里 macos-arm64 从同一域名下载正常，属 runner 瞬时 DNS 故障），而下载脚本对这类错误零重试，一次抖动就让整条发版链路失败。

## 改动

- **whisper-cpp-runtime**：产物只作为本次运行的临时产物（`actions/upload-artifact`），不再出现在 Release；矩阵内部命名契约不变。
- **build**：下载全部运行时产物，通过新环境变量 `DASHPLAYER_WHISPER_RUNTIME_DIR` 交给 `download.mjs`；缺某个平台产物时该平台在安装步骤显式失败，其余平台照常构建（行为不变）。
- **scripts/download.mjs**：抽出 `installBinaryFromArchive`（下载归档与本地归档共用安装路径）；whisper 运行时来源简化为两种——**CI 运行内产物** 与 **开发机本地源码编译**；删掉「从 Release 下载」路径与 `release:<version>` 标记，标记统一为 `source:<whisper.cpp ref>`。
- **删除 publish-runtime 任务**（及其 `release_tag` 输入，`release-please.yml` 同步去掉传参）：不再往 Release 传运行时，发版资产只剩安装包。安装包由 `electron-forge publish` 按 `package.json` 版本自行挂到对应 Release。
- **新增 scripts/network-retry.mjs + 下载重试**：`withNetworkRetry`（指数退避，默认 3 次尝试、2s/4s）+ `isRetryableNetworkError`（DNS/连接类错误、429/5xx、下载截断的 `HASH_MISMATCH`；404 这类确定性失败不重试）；`download` 拆成「单次尝试 + 带重试」，GitHub API 的两次发布查询也走同一套重试。
- **workflow_dispatch 新增 `package_only`**：只跑 `electron-forge make`，不发布、不碰 Release，用于在没有 tag 的分支上验证完整打包链路。

## 对开发机的影响

没有预编译产物时 `yarn run download` 会按固定 ref 本地编译 whisper.cpp（缺 cmake / Xcode / Vulkan SDK 会打印安装提示）；编不出来只跳过 whisper 引擎，应用仍可用 sherpa-onnx。用户侧的安装包不受影响（运行时已打进包里）。

## 验证

- **本地（已跑）**：伪造 `whisper-cpp-darwin-arm64.tar.gz` 放进临时目录 → `yarn run download` 按归档安装并写入 `source:<ref>` 标记；清空目录 + `CI=1` 重跑 → 以 1 退出并打印期望的归档路径。
- **重试模块（已跑）**：抖动两次后成功（3 次调用、100+200ms 退避）、404 只调用 1 次不重试、重试用尽后抛出最后一次错误；再跑一次完整 `yarn download`（全部命中缓存）exit 0。
- **CI（本分支干跑）**：`workflow_dispatch` + `package_only=true`，四平台完整打包（whisper 矩阵 → artifact → app `make`），不发布、不碰 Release。4 个 whisper 任务已全部 ✓，4 个 app 打包进行中。

## 后续（不在本 PR）

- 安装包的原子化上传：目前各平台仍由 `electron-forge publish` 各自上传，要彻底避免半成品 Release 需要改成「先 `make` 成 artifact、全部成功后再统一上传」。
- 每个平台只等自己平台的运行时（需要把 job 拆细）：产物约 4MB，收益有限。
