### PR TITLE
fix: 修复首次使用引导被启动门槛覆盖而永不展示

### DIFF
--- a/src/__tests__/app.startup-gate.test.tsx
+++ b/src/__tests__/app.startup-gate.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { App } from '../app';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock('@/fronted/i18n', () => ({
+    applyLanguageSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+/** 后端 IPC 调用替身；测试按路径指定启动门槛的返回值。 */
+const electronCall = window.electron.call as unknown as ReturnType<typeof vi.fn>;
+
+/** 按路径给启动门槛用到的 IPC 调用配置返回值。 */
+function stubStartupState(options: {
+    /** system/config/get 的返回值，代表引导完成版本。 */
+    onboardingCompletedVersion: string | null;
+    /** 迁移是否失败。 */
+    migrationFailed: boolean;
+}): void {
+    electronCall.mockImplementation((path: string) => {
+        if (path === 'system/config/get') {
+            return Promise.resolve(options.onboardingCompletedVersion);
+        }
+        if (path === 'migration-failure/detail') {
+            return Promise.resolve(
+                options.migrationFailed
+                    ? {
+                          failed: true,
+                          phase: 'custom',
+                          migrationId: 'store-schema-dictionary-youdao-v2',
+                          description: '清理有道词典链路存量数据',
+                          errorMessage: 'SQLITE_BUSY: database is locked',
+                      }
+                    : { failed: false, phase: null, migrationId: null, description: null, errorMessage: null }
+            );
+        }
+        if (path === 'watch-history/list/basic') {
+            return Promise.resolve([]);
+        }
+        return Promise.resolve({});
+    });
+}
+
+describe('应用启动门槛', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('从未完成过引导时，启动进入首次使用引导页', async () => {
+        stubStartupState({ onboardingCompletedVersion: null, migrationFailed: false });
+
+        render(<App />);
+
+        expect(await screen.findByText('steps.storage.heroTitle')).toBeDefined();
+    });
+
+    it('已完成过引导时，启动直接进入主界面', async () => {
+        stubStartupState({ onboardingCompletedVersion: '1', migrationFailed: false });
+
+        render(<App />);
+
+        expect(await screen.findByText('DashPlayer')).toBeDefined();
+        expect(screen.queryByText('steps.storage.heroTitle')).toBeNull();
+    });
+
+    it('迁移失败时优先进入启动恢复页，不再进入引导页', async () => {
+        stubStartupState({ onboardingCompletedVersion: null, migrationFailed: true });
+
+        render(<App />);
+
+        expect(await screen.findByText(/SQLITE_BUSY/)).toBeDefined();
+        expect(screen.queryByText('steps.storage.heroTitle')).toBeNull();
+        expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    it('启动门槛尚未判定完成时展示加载指示，不留白屏', () => {
+        // 两个门槛都挂着不返回，模拟判定尚未完成
+        electronCall.mockImplementation(() => new Promise(() => undefined));
+
+        render(<App />);
+
+        expect(screen.getByRole('status')).toBeDefined();
+        expect(screen.getByText('loading')).toBeDefined();
+    });
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -31,27 +31,69 @@ import type { MigrationFailureDetail } from '@/common/contracts/migration-failur
 import { Button } from '@/fronted/components/ui/button';
 import { backendClient } from '@/fronted/infrastructure/electron/backendClient';
 import { useTranslation as useI18nTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
 import { applyLanguageSetting } from '@/fronted/i18n';
 
 const UPDATE_CHECK_DELAY_MS = 6000;
 const UPDATE_TOAST_ID = 'update-available';
-const App = () => {
+
+/**
+ * 启动门槛的判定结果，优先级从高到低：迁移失败 → 首次使用引导 → 主界面。
+ *
+ * null 表示尚未判定完成：此时只展示轻量加载态，避免主界面先闪一下再被引导页顶掉。
+ */
+type StartupGate =
+    | { kind: 'migration-failure'; failure: MigrationFailureDetail }
+    | { kind: 'onboarding' }
+    | { kind: 'main' };
+
+/**
+ * 启动门槛判定期间的过渡态。
+ *
+ * 判定只等一轮 IPC 往返，但主界面挂载很重（首页会立即拉列表、改窗口尺寸），
+ * 所以这里只给一个轻量加载指示：既不先渲染主界面再切走，也不留一片空白。
+ */
+const StartupLoading: React.FC = () => {
+    const { t } = useI18nTranslation('common');
+    return (
+        <div
+            role="status"
+            className="flex h-full w-full items-center justify-center gap-2 text-muted-foreground"
+        >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-xs">{t('loading')}</span>
+        </div>
+    );
+};
+
+export const App = () => {
     const { t } = useI18nTranslation('toast');
     const theme = useSetting((s) => s.values.get('appearance.theme'));
     const languageSetting = useSetting((s) => s.values.get('i18n.language'));
-    const [needsOnboarding, setNeedsOnboarding] = React.useState<boolean | null>(null);
-    /** 迁移失败状态；null 表示已确认无失败（或读取失败时按无失败处理）。 */
-    const [migrationFailure, setMigrationFailure] = React.useState<MigrationFailureDetail | null>(null);
+    /** 当前生效的启动门槛；null 表示两个门槛都还没读出结果。 */
+    const [gate, setGate] = React.useState<StartupGate | null>(null);
 
+    // 两个门槛并行读取、统一裁决，避免各自为政时互相覆盖；
+    // 单次读取失败按「该门槛不拦截」处理，否则一次 IPC 异常就会把用户永久锁在启动页。
     useEffect(() => {
+        let cancelled = false;
         (async () => {
-            try {
-                const detail = await getMigrationFailureDetail();
-                setMigrationFailure(detail.failed ? detail : null);
-            } catch {
-                setMigrationFailure(null);
+            const [failure, completedVersion] = await Promise.all([
+                getMigrationFailureDetail().catch(() => null),
+                getOnboardingCompletedVersion().catch(() => null),
+            ]);
+            if (cancelled) {
+                return;
             }
+            if (failure?.failed) {
+                setGate({ kind: 'migration-failure', failure });
+                return;
+            }
+            setGate(completedVersion ? { kind: 'main' } : { kind: 'onboarding' });
         })();
+        return () => {
+            cancelled = true;
+        };
     }, []);
 
     useEffect(() => {
@@ -105,11 +147,13 @@ const App = () => {
     return (
         <>
             <div className="w-full h-screen text-black overflow-hidden select-none font-sans">
-                {migrationFailure ? (
-                    <MigrationFailureGate failure={migrationFailure} />
-                ) : needsOnboarding ? (
-                    <OnboardingView onCompleted={() => setNeedsOnboarding(false)} />
-                ) : (
+                {gate?.kind === 'migration-failure' && (
+                    <MigrationFailureGate failure={gate.failure} />
+                )}
+                {gate?.kind === 'onboarding' && (
+                    <OnboardingView onCompleted={() => setGate({ kind: 'main' })} />
+                )}
+                {gate?.kind === 'main' && (
                     <HashRouter>
                         <Routes>
                             <Route path="/" element={<HomePage />} />
@@ -183,6 +227,7 @@ const App = () => {
                         </Routes>
                     </HashRouter>
                 )}
+                {gate === null && <StartupLoading />}
             </div>
             <HotToaster
                 position="top-center"

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -100,6 +100,13 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => undefined
 }
 
+// jsdom 未实现 requestIdleCallback（首页列表用它做延迟加载），补一个立即执行的回调。
+if (!globalThis.requestIdleCallback) {
+  globalThis.requestIdleCallback = ((callback: IdleRequestCallback) =>
+    window.setTimeout(() => callback({ didTimeout: false, timeRemaining: () => 50 }), 0)) as typeof globalThis.requestIdleCallback
+  globalThis.cancelIdleCallback = ((handle: number) => window.clearTimeout(handle)) as typeof globalThis.cancelIdleCallback
+}
+
 // jsdom 未实现 canvas 2D 上下文（getContext 返回 null 并抛 Not implemented），
 // 引导页完成页的撒花动画（canvas-confetti）在卸载时会因空上下文报错。
 // 这里补一个只接受调用、不做真实绘制的上下文替身。


### PR DESCRIPTION
## 背景

有用户反馈：装上最新的包后**看不到首次使用引导页**。引导页代码本身早在 `4cab6a00`（2026-09-08）就合并进 main 了，`src/fronted/features/onboarding/*` 与对应 i18n 都在，但启动时永远不会被挂载。

## 根因

两天后的 `15c4526f feat: 迁移失败进入启动恢复页`（2026-09-10）在 `src/app.tsx` 里把「读取引导完成版本」的 `useEffect` **整段替换成了**「读取迁移失败状态」：

```diff
 useEffect(() => {
     (async () => {
         try {
-            const completedVersion = await getOnboardingCompletedVersion();
-            setNeedsOnboarding(!completedVersion);
+            const detail = await getMigrationFailureDetail();
+            setMigrationFailure(detail.failed ? detail : null);
         } catch {
-            setNeedsOnboarding(false);
+            setMigrationFailure(null);
         }
     })();
 }, []);
```

此后 `needsOnboarding` 只在引导完成时被置为 `false`，**没有任何地方把它置为 `true`**，渲染分支 `needsOnboarding ? <OnboardingView /> : <主界面>` 永远走主界面；`getOnboardingCompletedVersion` 也退化成一个未使用的 import。

这类事故没有被拦住的原因：ESLint 的 `no-unused-vars` 只是 `warn`（CI 没有质量门），而 `OnboardingView.test.tsx` 只测组件自身，没有任何测试覆盖「它会不会被挂载」。

## 影响面

只有 `v6.11.0`、`v6.11.1` 同时包含引导页代码与这个覆盖：

| 版本 | 含引导页代码 | 入口被覆盖 | 引导页实际可见 |
| --- | --- | --- | --- |
| v6.10.0 及更早 | 否 | — | 无此功能 |
| v6.11.0（仅 tag，未发 Release） | 是 | 是 | 否 |
| v6.11.1（当前 Pre-release，唯一已发布的含引导版本） | 是 | 是 | 否 |

也就是说 **6.11.x 的包从未向用户展示过引导页**，需要靠本 PR 修完再发一个 patch 版本，装了 6.11.x 的用户升级后才会走到引导。

## 改动

1. **启动门槛集中裁决**（`src/app.tsx`）：两个门槛并行读取、统一结算成一个 `StartupGate` 状态（union：`migration-failure` / `onboarding` / `main`），优先级「迁移失败 > 首次引导 > 主界面」。各写各的 `useEffect` 是这次互相覆盖的土壤，收成一个状态后新增门槛不会再顺手顶掉已有的。渲染侧三个分支互斥，由类型保证只有一个成立。
   - 单次读取失败仍按「该门槛不拦截」处理（沿用原行为），避免一次 IPC 异常把用户永久锁在启动页。
2. **判定期间展示轻量加载态**：主界面挂载很重（首页会立刻拉列表、`changeWindowSize('home')`），所以判定期间既不先渲染主界面再切走，也不留一片空白 —— 只给一个居中 spinner + `common.loading` 文案（复用已有 i18n key，没新造词条）。判定未完成前不再挂载首页。
3. **补 App 级启动门槛测试**（`src/__tests__/app.startup-gate.test.tsx`）：钉住四条分支与优先级（未完成引导→引导页、已完成→主界面、迁移失败→恢复页、判定中→加载态）。mock 只落在 `window.electron.call` 这个 IPC 边界上，页面/路由全部用真实实现。把修复回滚成原样时「进入引导页」这条会立刻失败。
4. `src/test/setup.ts` 补了 jsdom 缺失的 `requestIdleCallback`（首页列表的延迟加载用它）。

## 验证步骤

```bash
npx tsc --noEmit
npx eslint src/app.tsx src/__tests__/app.startup-gate.test.tsx src/test/setup.ts
yarn test:run        # 45 files / 304 passed, 21 skipped
```

手动验证引导页（二选一）：

- 全新 userData 目录启动应用 → 应直接进入引导页；
- 已有数据时清掉系统配置里的 `onboarding.completedVersion`（或直接重置数据库）后重启 → 同样应进入引导页；完成引导后重启不再展示。

顺带回归一下迁移失败路径：让一次启动迁移失败，应进入启动恢复页且**不再**进入引导页。

本 PR 不涉及 `drizzle/` 迁移，也不需要重新执行 `yarn run download`。

UI 变化仅一处：门槛判定期间的居中加载态（瞬态，通常几十毫秒），未附截图。
