### PR TITLE
fix: 修复播放任务竞态并校验修复名单路径

### DIFF
--- a/src/backend/services/PlaybackRepairService.ts
+++ b/src/backend/services/PlaybackRepairService.ts
@@ -323,6 +323,11 @@ export class PlaybackRepairServiceImpl implements PlaybackRepairService {
             return { groupKey: '', addedFiles: [] };
         }
 
+        // 入队时就拒绝失效路径，避免名单进入无法探测且会持续轮询的坏记录。
+        for (const filePath of filePaths) {
+            await this.assertRepairableSource(filePath);
+        }
+
         const groupKey = buildGroupKey(request.source, request.path, filePaths);
         const existing = new Set(
             (await this.repairGroupRepository.listMemberships())
@@ -593,6 +598,9 @@ export class PlaybackRepairServiceImpl implements PlaybackRepairService {
      * @param inputFile 待修复媒体绝对路径。
      */
     private async assertRepairableSource(inputFile: string): Promise<void> {
+        if (!MediaUtil.isMedia(inputFile)) {
+            throw new Error(`不支持修复的媒体格式：${inputFile}`);
+        }
         if (!await this.fileSystemGateway.fileExists(inputFile)) {
             throw new Error(`待修复的媒体文件不存在：${inputFile}`);
         }

--- a/src/fronted/features/player/repairPlayback.ts
+++ b/src/fronted/features/player/repairPlayback.ts
@@ -84,15 +84,33 @@ function parseProgress(result: string | null): number | null {
  */
 function watchTask(taskId: number, onUpdate: (task: DpTask) => void): Promise<DpTask> {
     return new Promise((resolve) => {
-        void registerDpTask(async () => taskId, {
-            onUpdated: (task) => onUpdate(task),
-            onFinish: (task) => resolve(task),
+        let settled = false;
+        const finish = (task: DpTask): void => {
+            if (!settled) {
+                settled = true;
+                resolve(task);
+            }
+        };
+        void (async () => {
+            await registerDpTask(async () => taskId, {
+                onUpdated: (task) => onUpdate(task),
+                onFinish: finish,
+            });
+            // 注册完成后再次检查，覆盖任务已在订阅建立前结束的竞态窗口。
+            const current = useDpTaskCenter.getState().tasks.get(taskId);
+            if (current && current !== 'init' && isFinalTask(current)) {
+                finish(current);
+            }
+        })().catch(() => {
+            finish({
+                id: taskId,
+                status: DpTaskState.FAILED,
+                progress: '读取修复任务状态失败',
+                result: null,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            });
         });
-        // 订阅建立前任务可能已经结束，这里补一次当前状态判断，避免永久等待。
-        const current = useDpTaskCenter.getState().tasks.get(taskId);
-        if (current && current !== 'init' && isFinalTask(current)) {
-            resolve(current);
-        }
     });
 }
 


### PR DESCRIPTION
## 背景

上个 PR（#252）把「修复播放问题」流程合进 main 后，实测发现两个会卡死流程的问题：

1. **前端订阅竞态**：`watchTask` 里「注册订阅」和「补一次当前状态判断」是同步执行的，但 `registerDpTask` 本身是异步的。如果任务在订阅真正建立之前就已经跑完，`onFinish` 永远不会触发，补判的那一次又因为订阅还没生效而读不到终态——修复进度条会永久停在原地。
2. **失效路径会污染修复名单**：`enqueueRepairTasks` 直接写库，路径是否真实存在、是否是支持的媒体格式要等到探测阶段才发现。结果名单里混进无效记录，无法探测、持续轮询，用户只能看着一行永远转圈。

## 改动

**前端：等待订阅真正建立后再补判（`repairPlayback.ts`）**

- 把注册过程放进 `async` 立即执行函数，`await registerDpTask(...)` 之后再做终态补偿判断，覆盖「任务已结束」的竞态窗口；
- 用 `settled` 标志保证 `finish` 只 resolve 一次，避免 `onFinish` 与补偿判断重复触发；
- 注册失败（如读取任务状态抛错）时兜底 resolve 为 `FAILED` 任务并带上失败文案，不再静默挂起。

**后端：入队即校验，坏路径不进名单（`PlaybackRepairService.ts`）**

- `enqueueRepairTasks` 在写库前对每个路径调用 `assertRepairableSource`，先失败先报，不落任何记录；
- `assertRepairableSource` 补上 `MediaUtil.isMedia` 格式校验，与「文件不存在」并列作为准入条件。

## 验证

- `yarn test:run`：361 passed / 9 skipped，50 个测试文件全绿（跳过项均为既有 `skip`，与本改动无关）；
- `npx tsc --noEmit` 无报错；
- `yarn lint` 0 error（57 warning，均为既有未使用变量提示）。

## 未验证

- 未在运行中的 app 里手工复现竞态窗口（后端任务在订阅建立前结束）与「塞入失效路径」两条路径，改动为纯逻辑修正 + 准入校验，靠类型与代码审查确认。

## 数据库迁移

无新增或修改迁移。
