### PR TITLE
fix: 修复名单添加文件只放行 mkv；中断后记录恢复强制修复入口

### DIFF
--- a/src/common/utils/MediaUtil.ts
+++ b/src/common/utils/MediaUtil.ts
@@ -8,6 +8,8 @@ export const SupportedAudioFormats = ['.mp3', '.wav', '.ogg', '.flac', '.m4a', '
 export const SupportedSubtitleFormats = ['.srt', '.vtt', '.ass'];
 export const AllFormats = [...SupportedVideoFormats, ...UnsupportedVideoFormats, ...SupportedAudioFormats, ...SupportedSubtitleFormats];
 export const SupportedFormats = [...SupportedVideoFormats, ...SupportedAudioFormats, ...SupportedSubtitleFormats];
+/** 全部媒体文件（视频 + 音频，不含字幕），与 {@link MediaUtil.isMedia} 的判定范围一致。 */
+export const MediaFormats = [...SupportedVideoFormats, ...UnsupportedVideoFormats, ...SupportedAudioFormats];
 export default class MediaUtil {
     public static isSrt(path: string): boolean {
         if (StrUtil.isBlank(path)) {

--- a/src/fronted/features/repair/components/RepairFileSelector.tsx
+++ b/src/fronted/features/repair/components/RepairFileSelector.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/fronted/components/ui/tooltip';
-import {cn} from "@/fronted/lib/utils";
-import {Button} from "@/fronted/components/ui/button";
-import { UnsupportedVideoFormats } from '@/common/utils/MediaUtil';
+import {Button} from '@/fronted/components/ui/button';
+import { MediaFormats } from '@/common/utils/MediaUtil';
 import { repairApi } from '../repairApi';
 import { useTranslation } from 'react-i18next';
 
@@ -13,26 +11,18 @@ export default function RepairFileSelector({
 }) {
     const { t } = useTranslation('common');
     const handleClick = async () => {
-        const ps = await repairApi.selectFiles(UnsupportedVideoFormats);
+        // 需不需要修复要靠探测，不能按扩展名筛：常见扩展名也可能带着放不出的音轨/编码。
+        const ps = await repairApi.selectFiles(MediaFormats);
         if (ps.length > 0) {
             await onSelected(ps);
         }
     };
 
     return (
-        <TooltipProvider>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        onClick={() => handleClick()}
-                        variant={'outline'}
-                        className={cn('w-28')}
-                    >{t('addFile')}</Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                    可以同时选择一个视频文件及其对应的字幕文件
-                </TooltipContent>
-            </Tooltip>
-        </TooltipProvider>
+        <Button
+            onClick={() => handleClick()}
+            variant={'outline'}
+            className="w-28"
+        >{t('addFile')}</Button>
     );
 }

--- a/src/fronted/features/repair/components/RepairItem.tsx
+++ b/src/fronted/features/repair/components/RepairItem.tsx
@@ -79,7 +79,7 @@ const RepairItem = ({ task, className, buttonVariant, onRepair, onForceRepair, o
     className?: string,
     buttonVariant?: 'default' | 'small';
     onRepair: () => void;
-    /** 指定配方强制重做，用于已判定「无需修复 / 已修复」的文件。 */
+    /** 指定配方强制重做；不想走自动配方的记录（已取消、失败、已丢弃、已判定无需修复）都可选用。 */
     onForceRepair: (recipe: RepairRecipe) => void;
     onRemove: () => void;
 }) => {
@@ -108,7 +108,7 @@ const RepairItem = ({ task, className, buttonVariant, onRepair, onForceRepair, o
 
     const isProbing = task.status === RepairTaskState.INIT;
     // 已经得出结论的行（无需修复 / 已修复）不再走自动配方：重复点只会被判成「无需修复」，
-    // 所以主按钮禁用，改由左侧「强制修复」让用户自己选做法。
+    // 所以主按钮禁用，改由「强制修复」让用户自己选做法。
     const isSettled = task.status === RepairTaskState.DONE;
     const forceRecipes: Array<{ recipe: RepairRecipe; label: string }> = isAudio
         ? [{ recipe: 'audio-transcode', label: t('playbackRepair.recipe.audioTranscode') }]
@@ -119,6 +119,9 @@ const RepairItem = ({ task, className, buttonVariant, onRepair, onForceRepair, o
         ];
     const isRunning = task.status === RepairTaskState.IN_PROGRESS
         || dpTask?.status === DpTaskState.IN_PROGRESS;
+    // 强制修复入口对一切可发起修复的行开放：取消（含应用重启中断）、失败或丢弃之后，
+    // 用户可能想换个配方重做，而不是重复刚才那条路径。
+    const canForceRepair = !isRunning && !isProbing;
     const preview = previewSource(task);
 
     /**
@@ -166,12 +169,13 @@ const RepairItem = ({ task, className, buttonVariant, onRepair, onForceRepair, o
     };
 
     /**
-     * 生成第二行说明：失败显示错误，待修复显示原因，其余显示路径。
+     * 生成第二行说明：失败显示错误，取消显示原因（如「应用重启导致修复中断」），
+     * 待修复显示原因，其余显示路径。
      *
      * @returns 说明文案。
      */
     const detailText = (): string => {
-        if (task.status === RepairTaskState.FAILED && task.error) {
+        if ((task.status === RepairTaskState.FAILED || task.status === RepairTaskState.CANCELLED) && task.error) {
             return task.error;
         }
         if (task.status === RepairTaskState.TODO && task.reason) {
@@ -249,7 +253,7 @@ const RepairItem = ({ task, className, buttonVariant, onRepair, onForceRepair, o
                             </div>
 
                             <div className="flex items-center gap-1.5">
-                                {isSettled && (
+                                {canForceRepair && (
                                     <DropdownMenu>
                                         <DropdownMenuTrigger asChild>
                                             <Button


### PR DESCRIPTION
## Summary
修复页面两处交互问题（均在 main 上存在，与 PR #256 独立）：

1. **添加文件只让选 mkv**：`RepairFileSelector` 把文件对话框过滤成了 `UnsupportedVideoFormats`（仅 `.mkv`），MP4 等常见格式根本选不上。按扩展名猜播放性问题与修复页逐个探测的设计矛盾（带 AC3 音轨的 MP4 同样要修），改为放行全部媒体格式（新增 `MediaFormats` 常量，与 `MediaUtil.isMedia` 范围一致）。顺手删掉遗留的「可同时选字幕文件」提示——修复入队本来就拒绝字幕。
2. **强退应用后强制修复入口消失**：重启会把进行中记录标成「已取消」，而强制修复下拉原先只在「已完成」行显示。改为对一切可发起修复的行（非修复中、非探测中）开放——取消/失败/丢弃之后可直接换配方重做；取消行的详情同时展示记录原因（如「应用重启导致修复中断」）。

## Test plan
- [x] `tsc --noEmit` 通过
- [x] 改动文件 ESLint 零问题
- [x] 前端测试 52 通过
- [ ] 真机验证：添加文件对话框可选 MP4/MP3 等；修复中强退应用重开后，该记录显示「已取消 + 应用重启导致修复中断」且有强制修复下拉