### PR TITLE
fix: 打包解出 Windows 动态库，修复装机版启动即崩

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -187,7 +187,10 @@ const config: ForgeConfig = {
             // 原生库必须解到 app.asar.unpacked：dyld/ld.so 读不了 asar 内部，
             // 例如 onnxruntime 的 binding.node 会按 @rpath（自身目录）找
             // libonnxruntime.*，只解包 .node 会导致 dlopen 报 Library not loaded。
-            unpack: '**/*.{wasm,node,dylib,so,so.*}',
+            // Windows 同理：onnxruntime_binding.node 的导入表直接依赖同目录的
+            // onnxruntime.dll / DirectML.dll，DLL 留在 asar 内时 LoadLibrary
+            // 报「找不到指定的模块」（126），装机后启动即崩。
+            unpack: '**/*.{wasm,node,dylib,dll,so,so.*}',
         },
         icon: './assets/icons/icon',
         extraResource: ['./drizzle', './lib', './scripts', './resources'],

--- a/src/backend/infrastructure/ai/LocalMtRuntime.ts
+++ b/src/backend/infrastructure/ai/LocalMtRuntime.ts
@@ -3,8 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import axios from 'axios';
-import { pipeline, env } from '@huggingface/transformers';
-import type { TranslationOutput } from '@huggingface/transformers';
+import type { pipeline, TranslationOutput } from '@huggingface/transformers';
 import TYPES from '@/backend/ioc/types';
 import StorageDirectoryProvider, { StorageDirectoryTarget } from '@/backend/services/gateways/storage/StorageDirectoryProvider';
 import { concurrency } from '@/backend/utils/concurrency';
@@ -273,8 +272,9 @@ export class LocalMtRuntime implements LocalMtService {
     }
 
     /**
-     * 懒加载翻译 pipeline；transformers.js 经动态 import 引入，
-     * 未启用该引擎时不为应用启动增加 onnxruntime 负担。
+     * 懒加载翻译 pipeline：transformers.js 经动态 import 引入（它在模块顶层就
+     * require('onnxruntime-node')，静态引入会让未启用本引擎的启动路径也加载
+     * onnx 原生库，原生库异常会连累整个应用启动失败）。
      * 加载本身不可取消（onnx 会话构建无中断点）；调用方在加载前后自行检查取消。
      */
     private async ensurePipeline(): Promise<MtPipeline> {
@@ -285,6 +285,7 @@ export class LocalMtRuntime implements LocalMtService {
                 throw new Error('轻量翻译模型未安装，请前往设置-服务凭据下载');
             }
             const startedAt = Date.now();
+            const { pipeline, env } = await import('@huggingface/transformers');
             // 进程级全局突变：目前仓库唯一的 transformers.js 使用点；若出现第二个
             // 使用者，这两行会静默影响它，届时应改为每次调用前设置或封装。
             env.allowLocalModels = true;


### PR DESCRIPTION
## 背景

Windows 装机版（6.11.0 ~ 6.12.0）安装后启动即崩，主进程弹框报 `The specified module could not be found`，路径指向 `onnxruntime_binding.node`。

根因：`asar.unpack` 的 glob 漏了 `dll`。`.node` 被解到 `app.asar.unpacked`，但它导入表里静态依赖的 `onnxruntime.dll` / `DirectML.dll` 还留在 `app.asar` 内部，LoadLibrary 解析不到就会抛错误码 126；6.11.1 修 macOS/Linux（`dylib`/`so`）时没有覆盖 Windows。

之所以是「装完就崩」而不是「用到才崩」：`LocalMtRuntime` 静态 import 了 `@huggingface/transformers`，而后者在模块顶层就 `require('onnxruntime-node')`，主进程启动路径上就会 dlopen onnx 原生库，未捕获异常直接弹框。

## 改动

- `forge.config.ts`：解包 glob 增加 `dll`（顺带解出 sharp 的 libvips DLL，Windows 上同样会踩）。
- `LocalMtRuntime.ts`：transformers.js 改为在 `ensurePipeline` 内动态 import，未启用本地翻译时不再加载 onnx 原生库，出问题也只影响该引擎本身。

## 验证

- 用 `@electron/asar` 的 `createPackageWithOptions` 实测两种 glob：旧规则只解出 `.node`，新规则把 `onnxruntime.dll`/`DirectML.dll` 一并解到 `app.asar.unpacked`；mac/Linux 的 `dylib`/`so`/`so.*` 匹配未受影响。
- 本机跑通完整 `electron-forge package`；对产物中解包出的 `.node` 做 dlopen：同目录动态库齐全时加载成功，把动态库移走立即报 `cannot open shared object file`（对应 Windows 的 126），确认因果链。
- 构建产物中 `@huggingface/transformers` 只剩 `ensurePipeline` 内一处 `await import`。
- `tsc` 干净；`yarn lint` 改动文件无新增问题；`yarn test:run` 49 passed / 1 skipped。

## 待真机验证

Windows 只能装包验证：确认应用能启动；「设置 → 轻量翻译」下载模型后能正常翻译（JSONL 日志有 `local mt pipeline loaded`）。

无需重跑 `yarn run download`，无 drizzle 迁移，无 UI 变化。