### PR TITLE
fix: Linux 打包命名统一为 dashplayer 以匹配窗口身份

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,21 @@ chmod +x DashPlayer-*.AppImage
 
 ```bash
 # Debian/Ubuntu 系
-sudo dpkg -i DashPlayer-*.deb
+sudo dpkg -i dashplayer_*.deb
 
 # Fedora/RHEL 系
-sudo rpm -i DashPlayer-*.rpm
+sudo rpm -i dashplayer-*.rpm
 ```
+
+> Linux 包名已由 `dash-player` 统一为 `dashplayer`（与桌面窗口身份一致）。安装过旧版本（6.12.x 及更早）的用户请先卸载旧包再安装，否则新旧两个版本会同时存在：
+>
+> ```bash
+> # Debian/Ubuntu 系
+> sudo apt remove dash-player
+>
+> # Fedora/RHEL 系
+> sudo rpm -e dash-player
+> ```
 
 3. 开始使用吧！
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -191,7 +191,10 @@ const config: ForgeConfig = {
         },
         icon: './assets/icons/icon',
         extraResource: ['./drizzle', './lib', './scripts', './resources'],
-        executableName: 'dash-player',
+        // Linux 命名统一为不带横杠的 dashplayer：此处 executableName、各 Linux maker 的
+        // name/bin 与 package.json 的 desktopName 必须一致，桌面环境才能把窗口（Wayland
+        // app_id / X11 WM_CLASS）匹配到安装包里的 dashplayer.desktop，否则 Dock 只显示通用占位图标。
+        executableName: 'dashplayer',
         name: 'DashPlayer',
     },
     rebuildConfig: {},
@@ -208,16 +211,16 @@ const config: ForgeConfig = {
         }),
         new MakerRpm({
             options: {
-                name: 'dash-player',
-                bin: 'dash-player',
+                name: 'dashplayer',
+                bin: 'dashplayer',
                 productName: 'DashPlayer',
                 icon: './assets/icons/icon.png',
             },
         }),
         new MakerDeb({
             options: {
-                name: 'dash-player',
-                bin: 'dash-player',
+                name: 'dashplayer',
+                bin: 'dashplayer',
                 productName: 'DashPlayer',
                 icon: './assets/icons/icon.png',
             },
@@ -227,8 +230,8 @@ const config: ForgeConfig = {
         // icon 给出 hicolor 多尺寸集合，maker 自动把最大尺寸作为 .DirIcon 默认图标。
         new MakerAppImage({
             options: {
-                name: 'dash-player',
-                bin: 'dash-player',
+                name: 'dashplayer',
+                bin: 'dashplayer',
                 productName: 'DashPlayer',
                 icon: {
                     '16x16': './assets/icons/16x16.png',
@@ -248,7 +251,7 @@ const config: ForgeConfig = {
             manufacturer: 'solidSpoon',
             version: packageJson.version,
             icon: './assets/icons/icon.ico',
-            exe: 'dash-player.exe',
+            exe: 'dashplayer.exe',
             ui: {
                 chooseDirectory: true,
             },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "6.11.2",
   "description": "A video player designed for English learning",
   "main": ".vite/build/main.js",
+  "desktopName": "dashplayer.desktop",
   "scripts": {
     "download": "zx ./scripts/download.mjs",
     "build:dictionary": "node scripts/build-dictionary.mjs",


### PR DESCRIPTION
## 背景

Linux 上 Dock 显示通用灰色占位图标：窗口身份是 Electron 从 productName 自动派生的 `dashplayer`，而安装包里的启动器名为 `dash-player.desktop`（electron-installer-common 把 `.desktop` 文件名直接绑在 deb/rpm 包名上），GNOME 匹配不到启动器。AppImage 内部还存在第三个名字 `DashPlayer.desktop`。

## 改动

- `package.json` 增加 `"desktopName": "dashplayer.desktop"`，作为窗口身份的唯一来源（Electron 引导层与 @reforged/maker-appimage 都读它）
- `forge.config.ts` 把 `executableName`、deb/rpm/AppImage 的 `name`/`bin`、Wix 的 `exe` 统一为不带横杠的 `dashplayer`，并注释了三处必须同名的不变量；同时删掉 src/main.ts 里重复的 `app.setDesktopName` 声明，避免两处失配再犯
- `README.md` 的 deb/rpm 安装命令改为真实产物名 `dashplayer_*.deb` / `dashplayer-*.rpm`（原来写的 `DashPlayer-*.deb` 本就不匹配实际产物），并注明旧包需先卸载

## 验证

- **窗口身份实测**：用项目同版本 Electron 44.2.0 起最小应用，代码不调用、只在 package.json 声明 `desktopName`，`WAYLAND_DEBUG=1` 观察到 `xdg_toplevel.set_app_id("dashplayer")`；把值改成探测值 `dpverify-probe.desktop` 后 app_id 随之变化，确认该字段真实生效（而非恰好被 productName 兜底掩盖）
- **deb 打包实测**：用同版本 electron-installer-debian 3.2.0（配置项与 `MakerDeb` 一致）打探针包，产物 `dashplayer_0.0.1_amd64.deb`，内含 `/usr/share/applications/dashplayer.desktop`（`Exec=dashplayer %U`、`Icon=dashplayer`、`Name=DashPlayer`）、`/usr/bin/dashplayer -> ../lib/dashplayer/dashplayer`、`/usr/share/pixmaps/dashplayer.png`
- **未实测**：rpm / AppImage（本机无 rpmbuild，已按 maker 源码逐行核对命名来源同源）；未跑全量打包，真实产物由 CI 产出。本机也无法截图确认 Dock 图标，验证做到「安装包文件名 + 桌面文件内容 + 协议层 app_id」三者一致

## 破坏性变更

deb/rpm 包名由 `dash-player` 改为 `dashplayer`，与旧包安装路径不重叠、可以共存，因此老用户升级前需先卸载旧包；Dock 上指向旧启动器的固定项需重新固定。安装包内的应用数据目录不受影响（仍是 `~/.config/DashPlayer`）。

> 涉及 `drizzle/` 迁移：无。需要重新执行 `yarn run download`：否。