### PR TITLE
fix: Windows whisper 运行时零外部依赖（静态 CRT + 随包 vcomp140/vulkan-1）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,9 @@ jobs:
         if: matrix.os.name == 'windows'
         run: |
           choco install wixtoolset
-          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+          # pwsh 里环境变量必须写 $env:GITHUB_PATH；裸 $GITHUB_PATH 是未定义 PS 变量，
+          # 重定向会静默失败
+          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\WiX Toolset v3.11\bin"
       # AppImage maker (@reforged/maker-appimage) 需要系统提供 mksquashfs，
       # 显式安装而不依赖 runner 镜像恰好预装
       - name: Install squashfs-tools (Linux only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       # 运行时基于固定版本的 whisper.cpp 构建；parakeet-cli 输出格式是
       # 解析契约（见 WhisperCppCli.parseOutput），升级前需重新验证
       WHISPER_CPP_REF: 52a939a2a762224e255d366c1182b2af4dd1a032
+      # Vulkan SDK 版本：必须 1.4.x（1.3.290 不带 SPIRV-Headers 的 cmake config），
+      # 与 llama.cpp 保持一致；vulkan-1.dll 也从同版本的官方运行包里取，见 Package 步骤
+      VULKAN_VERSION: 1.4.357.0
     steps:
       - name: Checkout whisper.cpp
         uses: actions/checkout@v5
@@ -76,12 +79,6 @@ jobs:
       - name: Install Vulkan SDK (Windows only)
         if: matrix.gpu == 'vulkan' && runner.os == 'Windows'
         shell: pwsh
-        env:
-          # 必须用 1.4.x：1.3.290 的 SDK 不带 SPIRV-Headers 的 cmake config，
-          # 而 ggml 的 ggml-vulkan 是 find_package(SPIRV-Headers CONFIG REQUIRED)
-          # （实测 1.3.290 报 Could not find a package configuration file
-          # provided by "SPIRV-Headers"）；与 llama.cpp 的版本保持一致
-          VULKAN_VERSION: 1.4.357.0
         run: |
           curl.exe -L -o "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" "https://sdk.lunarg.com/sdk/download/$env:VULKAN_VERSION/windows/vulkansdk-windows-X64-$env:VULKAN_VERSION.exe"
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
@@ -89,11 +86,22 @@ jobs:
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$env:VULKAN_VERSION\bin"
       - name: Configure (Vulkan)
         if: matrix.gpu == 'vulkan'
-        env:
-          # Windows 用静态 CRT（/MT）：MSVC 默认 /MD 会让 parakeet-cli.exe 依赖
-          # VCRUNTIME140.dll / MSVCP140.dll（来自 VC++ Redistributable，干净系统上不保证存在）
-          MSVC_RUNTIME_FLAG: ${{ runner.os == 'Windows' && '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded' || '' }}
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=OFF $MSVC_RUNTIME_FLAG
+        # Windows 上两个参数必须一起给，都是为了让 parakeet-cli.exe 在干净 Windows
+        # （未装 VC++ Redistributable）上能起来：
+        # - CMAKE_POLICY_DEFAULT_CMP0091=NEW：whisper.cpp 顶层 cmake_minimum_required
+        #   是 3.5（ggml 是 3.14），CMP0091 为 OLD 时 CMAKE_MSVC_RUNTIME_LIBRARY 会被
+        #   静默忽略，/MT 不生效；
+        # - CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded：静态 CRT，去掉
+        #   VCRUNTIME140.dll / MSVCP140.dll 依赖。
+        # OpenMP 保持开启（不传 GGML_OPENMP=OFF）：MSVC 的 OpenMP 运行时只有 DLL 形式、
+        # 无法静态链接，但关掉它实测 encode 慢 ~30%、decode 慢一个量级（VM 内新旧二进制
+        # 交替跑对比），因此改为随包分发 vcomp140.dll（见 Package 步骤；该 DLL 只依赖
+        # KERNEL32，本身零外部依赖）。
+        # 参数用 ${{ }} 表达式内联而不是步骤 env + $VAR：Windows 的 run 默认 shell 是
+        # pwsh，POSIX 的 $VAR 语法不展开、参数会静默丢失（历史上 /MT 因此从未生效）。
+        # Vulkan 必须留在链接期（ggml-vulkan 硬依赖 vulkan-1.dll，非 delay-load），
+        # 由 Package 步骤把官方 loader 打进运行包
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=OFF ${{ runner.os == 'Windows' && '-DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded' || '' }}
       - name: Configure (Metal)
         if: matrix.gpu == 'metal'
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DCMAKE_OSX_ARCHITECTURES=${{ contains(matrix.name, 'arm64') && 'arm64' || 'x86_64' }} -DBUILD_SHARED_LIBS=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=OFF
@@ -107,11 +115,52 @@ jobs:
           mkdir -p stage
           if [ "${{ runner.os }}" = "Windows" ]; then
             cp build/bin/Release/parakeet-cli.exe stage/parakeet-cli.exe
-            (cd stage && 7z a "../whisper-cpp-${{ matrix.name }}.zip" parakeet-cli.exe)
+            # ggml-vulkan 对 vulkan-1.dll 是硬链接依赖（非 delay-load）：干净 Windows
+            # （无独显驱动、未装 VC 运行库）的 system32 里没有它，缺了进程在加载期就死
+            # （0xC0000135，stderr 为空）。取官方运行包里的 x64 loader 与许可证，
+            # 放在 exe 同目录一起分发（DLL 搜索顺序里 exe 目录优先于 system32）；
+            # 运行包里带 x86 版本与 pdb，按路径只取 x64
+            rm -rf vkrt-download vkrt-extract
+            mkdir -p vkrt-download vkrt-extract
+            curl.exe -fsSL -o vkrt-download/vulkan-runtime-components.zip "https://sdk.lunarg.com/sdk/download/$VULKAN_VERSION/windows/vulkan-runtime-components.zip"
+            7z x -y vkrt-download/vulkan-runtime-components.zip -ovkrt-extract > /dev/null
+            cp "$(find vkrt-extract -path '*/x64/vulkan-1.dll' -print -quit)" stage/vulkan-1.dll
+            cp "$(find vkrt-extract -name 'VulkanRT-License.txt' -print -quit)" stage/VulkanRT-License.txt
+            # OpenMP 运行时（vcomp140.dll）同理要跟着 exe 走：MSVC 的 OpenMP 只有 DLL 形式，
+            # /MT 也去不掉它，而关掉 OpenMP 实测 encode 慢 ~30%、decode 慢一个量级。
+            # 取系统里的那份（vc_redist 装进 System32 的版本，只依赖 KERNEL32）：VS 自带的
+            # app-local 副本（VC/Redist/MSVC/*/x64/Microsoft.VC14*.OpenMP/）是另一个构建，
+            # 自己依赖 VCRUNTIME140 + UCRT，拿它等于把刚用 /MT 去掉的依赖又请回来（实测被
+            # Verify 步骤拦下）。runner 镜像自带 VC++ Redistributable，缺件就 fail-closed
+            VCOMP="$(cygpath -u "${SystemRoot:-C:\\Windows}")/System32/vcomp140.dll"
+            [ -f "$VCOMP" ] || { echo "[FAIL] 找不到 $VCOMP：runner 缺少 VC++ Redistributable"; exit 1; }
+            cp "$VCOMP" stage/vcomp140.dll
+            (cd stage && 7z a "../whisper-cpp-${{ matrix.name }}.zip" parakeet-cli.exe vulkan-1.dll vcomp140.dll VulkanRT-License.txt)
           else
             cp build/bin/parakeet-cli stage/parakeet-cli
             (cd stage && tar czf "../whisper-cpp-${{ matrix.name }}.tar.gz" parakeet-cli)
           fi
+      - name: Verify Windows runtime dependencies (Windows only)
+        # 干净 Windows 上起不来等于运行时废了（加载期 0xC0000135，stderr 为空、日志里只剩
+        # 一个退出码），所以在这里当场断言，而不是等用户报错。断言的是完整契约：
+        #   - parakeet-cli.exe 的全部非系统依赖，恰好就是随包附带的两个 DLL；
+        #   - 这两个 DLL 自身只依赖系统 DLL（附带的 DLL 自己还带依赖就等于没修）；
+        #   - exe 确实导入了它们（拦住“参数静默丢失”这类回归：/MT 没生效、OpenMP 被关掉，
+        #     历史上 $VAR 在 pwsh 下不展开就出过这种事）。
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
+          dumpbin /dependents stage\parakeet-cli.exe > dependents.txt
+          dumpbin /dependents stage\vulkan-1.dll >> dependents.txt
+          dumpbin /dependents stage\vcomp140.dll >> dependents.txt
+          type dependents.txt
+          if not exist stage\vulkan-1.dll (echo [FAIL] stage\vulkan-1.dll missing & exit /b 1)
+          if not exist stage\vcomp140.dll (echo [FAIL] stage\vcomp140.dll missing & exit /b 1)
+          findstr /i /r "MSVCP[0-9] VCRUNTIME[0-9] CONCRT[0-9] api-ms-win-crt UCRTBASE" dependents.txt > nul && (echo [FAIL] VC runtime dependency found: expect static CRT and vcomp140.dll only & exit /b 1)
+          findstr /i /c:"vulkan-1.dll" dependents.txt > nul || (echo [FAIL] parakeet-cli.exe does not import vulkan-1.dll & exit /b 1)
+          findstr /i /c:"VCOMP140.DLL" dependents.txt > nul || (echo [FAIL] parakeet-cli.exe does not import VCOMP140.DLL & exit /b 1)
+          echo [OK] staged DLLs cover every non-system dependency of parakeet-cli.exe
       - name: Upload runtime artifact
         # 只留在本次运行内：app 构建要的就是同一份二进制，直接递过去，
         # 既不用等 Release 先存在，也不会在构建失败时留下“有运行时、没安装包”的半成品 Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
       # 解析契约（见 WhisperCppCli.parseOutput），升级前需重新验证
       WHISPER_CPP_REF: 52a939a2a762224e255d366c1182b2af4dd1a032
       # Vulkan SDK 版本：必须 1.4.x（1.3.290 不带 SPIRV-Headers 的 cmake config），
-      # 与 llama.cpp 保持一致；vulkan-1.dll 也从同版本的官方运行包里取，见 Package 步骤
+      # 与 llama.cpp 保持一致；vulkan-1.dll 也从同版本的官方运行包里取，见 Package 步骤。
+      # 改这个版本号时必须同步 scripts/download.mjs 的 VULKAN_RUNTIME_VERSION：
+      # 那边把它自动并进运行时配方标记，旧装机才会重装拿到新 loader
       VULKAN_VERSION: 1.4.357.0
     steps:
       - name: Checkout whisper.cpp
@@ -131,7 +133,9 @@ jobs:
             # 取系统里的那份（vc_redist 装进 System32 的版本，只依赖 KERNEL32）：VS 自带的
             # app-local 副本（VC/Redist/MSVC/*/x64/Microsoft.VC14*.OpenMP/）是另一个构建，
             # 自己依赖 VCRUNTIME140 + UCRT，拿它等于把刚用 /MT 去掉的依赖又请回来（实测被
-            # Verify 步骤拦下）。runner 镜像自带 VC++ Redistributable，缺件就 fail-closed
+            # Verify 步骤拦下）。runner 镜像自带 VC++ Redistributable，缺件就 fail-closed。
+            # vcomp140.dll 属微软可再分发代码：app-local 副本不随 Windows Update 更新，
+            # 微软给 CRT/OpenMP 发安全更新时需跟版重建，别当成“已经永久修好”
             VCOMP="$(cygpath -u "${SystemRoot:-C:\\Windows}")/System32/vcomp140.dll"
             [ -f "$VCOMP" ] || { echo "[FAIL] 找不到 $VCOMP：runner 缺少 VC++ Redistributable"; exit 1; }
             cp "$VCOMP" stage/vcomp140.dll

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -584,6 +584,28 @@ async function download({url, dir, file, sha}) {
 const WHISPER_CPP_REF = '52a939a2a762224e255d366c1182b2af4dd1a032';
 
 /**
+ * 运行时配方版本：构建参数或“随包附带文件”一变就必须 +1。
+ * 同一 ref 不同配方产出的二进制不可互换（r3 = Windows 静态 CRT + OpenMP + 附带
+ * vulkan-1.dll/vcomp140.dll），标记里带上它，已装的旧配方运行时才会被重装而不是继续沿用。
+ */
+const WHISPER_RUNTIME_RECIPE = 'r3';
+
+/**
+ * Windows 侧 ggml-vulkan 对 vulkan-1.dll 是硬链接依赖（非 delay-load）：干净系统
+ * （无独显驱动、未装 VC 运行库）的 system32 里没有它，缺了进程在加载期就死。
+ * loader 取 LunarG 官方运行包（Apache-2.0/MIT，许可证随包附带），
+ * 版本与 release.yml 的 VULKAN_VERSION 对齐。
+ */
+const VULKAN_RUNTIME_VERSION = '1.4.357.0';
+const VULKAN_RUNTIME_COMPONENTS_URL = `https://sdk.lunarg.com/sdk/download/${VULKAN_RUNTIME_VERSION}/windows/vulkan-runtime-components.zip`;
+
+/**
+ * MSVC 的 OpenMP 运行时文件名：只有 DLL 形式、/MT 也去不掉（见
+ * installOpenMpRuntimeForWindows），与 vulkan-1.dll 一样必须与 exe 同目录分发。
+ */
+const VCOMP_DLL_NAME = 'vcomp140.dll';
+
+/**
  * 运行时目录中的来源标记文件名：记录已安装的二进制来自哪个 Release 版本或哪个源码 ref。
  * 只判文件存在无法区分“装的是哪一份”，会让人在换 ref / 换版本后继续沿用旧二进制。
  */
@@ -611,6 +633,79 @@ const readWhisperRuntimeMarker = (markerPath) => {
  */
 const whisperRuntimeAssetName = (platform, arch) =>
     `whisper-cpp-${platform}-${arch}.${platform === 'win32' ? 'zip' : 'tar.gz'}`;
+
+/**
+ * 下载 LunarG 官方 Vulkan 运行包，把 x64 的 vulkan-1.dll 与许可证安装到目标目录。
+ *
+ * Windows 上 parakeet-cli.exe 对 vulkan-1.dll 是硬链接依赖（非 delay-load），而干净系统
+ * （无独显驱动、未装 VC 运行库）的 system32 里没有它，缺了进程在加载期就死（0xC0000135，
+ * stderr 为空）。exe 目录在 DLL 搜索顺序里优先于 system32，所以 loader 与 exe 同目录分发。
+ * 运行包同时含 x86 版本与 pdb，只取 x64；与 release.yml 的 Package 步骤同一来源、同一版本。
+ *
+ * @param {string} targetDir loader 与许可证的落地目录（exe 同级）。
+ * @returns {Promise<void>} 下载、解压或拷贝失败时抛出。
+ */
+async function installVulkanLoaderForWindows(targetDir) {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dashplayer-vulkan-'));
+    const archiveName = 'vulkan-runtime-components.zip';
+    await download({url: VULKAN_RUNTIME_COMPONENTS_URL, dir: tmpRoot, file: archiveName});
+    const extractDir = path.join(tmpRoot, 'extract');
+    await extractArchive(path.join(tmpRoot, archiveName), extractDir);
+
+    const loader = findFirstFile(
+        extractDir,
+        (p) => /^x64$/i.test(path.basename(path.dirname(p))) && path.basename(p).toLowerCase() === 'vulkan-1.dll',
+        12
+    );
+    if (!loader) throw new Error(`Vulkan 运行包里找不到 x64/vulkan-1.dll：${VULKAN_RUNTIME_COMPONENTS_URL}`);
+    const license = findFirstFile(extractDir, (p) => path.basename(p) === 'VulkanRT-License.txt', 12);
+    if (!license) throw new Error(`Vulkan 运行包里找不到 VulkanRT-License.txt：${VULKAN_RUNTIME_COMPONENTS_URL}`);
+
+    for (const src of [loader, license]) {
+        const dest = path.join(targetDir, path.basename(src));
+        fs.copyFileSync(src, dest);
+        console.info(chalk.green(`✅ vulkan runtime: ${src} -> ${dest}`));
+    }
+}
+
+/**
+ * 把系统里的 vcomp140.dll（vc_redist 装进 System32 的那份）装到目标目录。
+ *
+ * MSVC 的 OpenMP 运行时只有 DLL 形式、无法静态链接，而关掉 OpenMP 实测 encode 慢
+ * ~30%、decode 慢一个量级（VM 内新旧二进制交替跑对比），因此与 vulkan-1.dll 同样
+ * 随 exe 分发。必须取 System32 的副本：那份是零外部依赖的（只依赖 KERNEL32），而
+ * VS 自带的 app-local 副本（Redist 目录下 x64 的 Microsoft.VC14x.OpenMP）依赖
+ * VCRUNTIME140 + UCRT，会把 /MT 去掉的依赖又请回来。与 release.yml 的 Package 步骤同源。
+ *
+ * @param {string} targetDir vcomp140.dll 的落地目录（exe 同级）。
+ * @returns {Promise<void>} 系统里没有该 DLL（未装 VC++ Redistributable）时抛出。
+ */
+async function installOpenMpRuntimeForWindows(targetDir) {
+    const src = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', VCOMP_DLL_NAME);
+    if (!fs.existsSync(src)) {
+        throw new Error(`找不到 ${src}：Windows 本地构建 whisper.cpp 需要先安装 VC++ Redistributable（微软官方 vc_redist.x64.exe）`);
+    }
+    const dest = path.join(targetDir, VCOMP_DLL_NAME);
+    fs.copyFileSync(src, dest);
+    console.info(chalk.green(`✅ openmp runtime: ${src} -> ${dest}`));
+}
+
+/**
+ * 校验 Windows whisper.cpp 运行时是否与 exe 配套：exe 对 vulkan-1.dll（ggml-vulkan
+ * 硬依赖）与 vcomp140.dll（MSVC OpenMP 运行时，/MT 去不掉）都是硬链接依赖，缺任何一个
+ * 在干净系统上都是加载期直接失败（0xC0000135、stderr 为空），必须当场抛错，
+ * 而不是留下一个默认识别引擎不可用的运行时。
+ * @param {string} basePath 运行时目录。
+ */
+const assertWhisperWindowsRuntimeComplete = (basePath) => {
+    if (platform !== 'win32') return;
+    for (const name of ['vulkan-1.dll', VCOMP_DLL_NAME]) {
+        const dllPath = path.join(basePath, name);
+        if (!fs.existsSync(dllPath)) {
+            throw new Error(`whisper.cpp Windows 运行时缺少 ${name}：${dllPath}，parakeet-cli 在干净系统上会直接起不来`);
+        }
+    }
+};
 
 /**
  * 本地源码构建 whisper.cpp parakeet-cli（开发机获取运行时的唯一路径）。
@@ -694,10 +789,20 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
         ? ['-DGGML_METAL=ON', '-DGGML_METAL_USE_BF16=ON', '-DGGML_METAL_EMBED_LIBRARY=ON', `-DCMAKE_OSX_ARCHITECTURES=${arch === 'arm64' ? 'arm64' : 'x86_64'}`]
         : [
             '-DGGML_VULKAN=ON',
-            // Windows 用静态 CRT（/MT），与 release.yml 对齐：MSVC 默认 /MD 会让二进制
-            // 依赖 VCRUNTIME140.dll / MSVCP140.dll（来自 VC++ Redistributable，不保证存在）
-            ...(platform === 'win32' ? ['-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'] : []),
+            // Windows 两个参数与 release.yml 的 Configure (Vulkan) 步骤逐字对齐，缺一不可：
+            // CMP0091 为 OLD 时 CMAKE_MSVC_RUNTIME_LIBRARY 会被静默忽略（whisper.cpp 顶层
+            // cmake_minimum_required 只有 3.5），必须显式抬成 NEW；静态 CRT 去
+            // VCRUNTIME140.dll / MSVCP140.dll。OpenMP 保持开启（关掉实测 encode 慢 ~30%、
+            // decode 慢一个量级），vcomp140.dll 由 installOpenMpRuntimeForWindows 随包附带
+            ...(platform === 'win32'
+                ? ['-DCMAKE_POLICY_DEFAULT_CMP0091=NEW', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']
+                : []),
         ];
+    if (platform === 'win32') {
+        // 与 exe 配套的两个 DLL 先落地：缺件要在开跑几分钟编译之前就暴露
+        await installVulkanLoaderForWindows(basePath);
+        await installOpenMpRuntimeForWindows(basePath);
+    }
     console.info(chalk.blue('=> Building whisper.cpp parakeet-cli (first build takes a few minutes)...'));
     try {
         execSync(
@@ -726,6 +831,7 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
         return false;
     }
     fs.copyFileSync(builtPath, path.join(basePath, exeName));
+    assertWhisperWindowsRuntimeComplete(basePath);
     console.info(chalk.green(`✅ whisper.cpp parakeet-cli built and installed to ${basePath}`));
     return true;
 }
@@ -760,9 +866,9 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
         const localArchiveExists = Boolean(localArchivePath && fs.existsSync(localArchivePath));
 
         // parakeet-cli 的输出格式是解析契约（见 WhisperCppCli.parseOutput），所以已装的
-        // 二进制必须带上来源：标记与预期不符（换了 whisper.cpp ref / 手工放置）就重新安装。
-        // 运行时只由固定 ref 的源码构建产出，因此标记统一是 source:<ref>。
-        const expectedMarker = `source:${WHISPER_CPP_REF}`;
+        // 二进制必须带上来源：标记与预期不符（换了 whisper.cpp ref / 换了配方 / 手工放置）
+        // 就重新安装。二进制内容由 ref 与配方共同决定，标记统一是 source:<ref>+<配方>。
+        const expectedMarker = `source:${WHISPER_CPP_REF}+${WHISPER_RUNTIME_RECIPE}`;
         const installedMarker = readWhisperRuntimeMarker(markerPath);
         if (fs.existsSync(exePath) && installedMarker === expectedMarker) {
             console.info(chalk.green(`✅ File ${exeName} already exists (${expectedMarker})`));
@@ -777,7 +883,10 @@ async function buildWhisperCppFromSource({ basePath, exeName }) {
                     archivePath: localArchivePath,
                     outputPath: exePath,
                     binaryNameCandidates: ['parakeet-cli', 'parakeet-cli.exe'],
+                    // Windows 归档里 exe 之外还有 loader、OpenMP 运行时与许可证（release.yml 的 Package 步骤打包）
+                    extraCopyPatterns: platform === 'win32' ? [/^vulkan-1\.dll$/i, /^vcomp140\.dll$/i, /^VulkanRT-License\.txt$/] : [],
                 });
+                assertWhisperWindowsRuntimeComplete(basePath);
                 fs.writeFileSync(markerPath, `${expectedMarker}\n`);
             } else if (process.env.CI) {
                 // CI 上不许编译兜底：缺运行时说明 whisper-cpp-runtime 没产出该平台产物，

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -678,6 +678,10 @@ async function installVulkanLoaderForWindows(targetDir) {
  * VS 自带的 app-local 副本（Redist 目录下 x64 的 Microsoft.VC14x.OpenMP）依赖
  * VCRUNTIME140 + UCRT，会把 /MT 去掉的依赖又请回来。与 release.yml 的 Package 步骤同源。
  *
+ * vcomp140.dll 属于微软可再分发代码（见“Redistributing Visual C++ Files”文档）。这是
+ * app-local 分发：该副本不随 Windows Update 更新，微软给 CRT/OpenMP 发安全更新时，
+ * 需要跟版重建运行时包，不要当成“已经永久修好”。
+ *
  * @param {string} targetDir vcomp140.dll 的落地目录（exe 同级）。
  * @returns {Promise<void>} 系统里没有该 DLL（未装 VC++ Redistributable）时抛出。
  */

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -584,13 +584,6 @@ async function download({url, dir, file, sha}) {
 const WHISPER_CPP_REF = '52a939a2a762224e255d366c1182b2af4dd1a032';
 
 /**
- * 运行时配方版本：构建参数或“随包附带文件”一变就必须 +1。
- * 同一 ref 不同配方产出的二进制不可互换（r3 = Windows 静态 CRT + OpenMP + 附带
- * vulkan-1.dll/vcomp140.dll），标记里带上它，已装的旧配方运行时才会被重装而不是继续沿用。
- */
-const WHISPER_RUNTIME_RECIPE = 'r3';
-
-/**
  * Windows 侧 ggml-vulkan 对 vulkan-1.dll 是硬链接依赖（非 delay-load）：干净系统
  * （无独显驱动、未装 VC 运行库）的 system32 里没有它，缺了进程在加载期就死。
  * loader 取 LunarG 官方运行包（Apache-2.0/MIT，许可证随包附带），
@@ -598,6 +591,14 @@ const WHISPER_RUNTIME_RECIPE = 'r3';
  */
 const VULKAN_RUNTIME_VERSION = '1.4.357.0';
 const VULKAN_RUNTIME_COMPONENTS_URL = `https://sdk.lunarg.com/sdk/download/${VULKAN_RUNTIME_VERSION}/windows/vulkan-runtime-components.zip`;
+
+/**
+ * 运行时配方版本：构建参数一变就必须手动 +1；随包 loader 的版本由
+ * VULKAN_RUNTIME_VERSION 自动并入标记，升级 loader 不必再手动 bump（r3 = Windows
+ * 静态 CRT + OpenMP + 附带 vulkan-1.dll/vcomp140.dll）。同一 ref 不同配方产出的二进制
+ * 不可互换，标记里带上它，已装的旧配方运行时才会被重装而不是继续沿用。
+ */
+const WHISPER_RUNTIME_RECIPE = `r3+vk${VULKAN_RUNTIME_VERSION}`;
 
 /**
  * MSVC 的 OpenMP 运行时文件名：只有 DLL 形式、/MT 也去不掉（见


### PR DESCRIPTION
## 背景

干净 Windows（未装 VC++ Redistributable）上使用 whisper.cpp 引擎转录会直接失败：`parakeet-cli.exe` 在加载期就挂掉（退出码 3221225781 = `0xC0000135 STATUS_DLL_NOT_FOUND`，stderr 为空，应用日志里只剩一个退出码）。用 Win10 LTSC 干净虚拟机复现并做了二进制级取证：

- 从官方 v6.12.1 安装包里取出的 exe 与 VM 里运行的 exe 哈希完全一致，是官方产物的通病，不是个案；
- exe 导入表硬依赖 `MSVCP140.dll`、`VCRUNTIME140.dll`、`VCRUNTIME140_1.dll`、`VCOMP140.DLL`、`vulkan-1.dll`，干净系统一个都没有；
- 历史 CI 里的「静态 CRT」（`-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`）从未生效：whisper.cpp 顶层 `cmake_minimum_required` 只有 3.5，CMP0091 为 OLD 时该变量被静默忽略；
- ggml-vulkan 对 `vulkan-1.dll` 是硬链接依赖（非 delay-load），而 exe 在 `resources\lib\whisper-cpp\x64\win32\` 子目录、spawn cwd 也是那里，加载不到应用根目录下 Electron 自带的那个 `vulkan-1.dll`。

## 改动

**`.github/workflows/release.yml`（Windows 运行时构建与打包）**

- Configure 步骤补 `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW`，让静态 CRT 真正生效，去掉 `VCRUNTIME140`/`MSVCP140` 依赖；参数用 `${{ }}` 表达式内联（Windows `run:` 默认 pwsh，POSIX `$VAR` 不展开、参数会静默丢失）；
- OpenMP 保持开启：关掉后实测 encode 慢约 30%、decode 慢一个量级，不可接受；改为把 `vcomp140.dll` 随包分发——取 System32 里 vc_redist 安装的那份（只依赖 KERNEL32），而不是 VS 自带的 app-local 副本（后者自身依赖 `VCRUNTIME140` + UCRT，等于把刚去掉的依赖请回来，第一版干跑被 Verify 步骤当场拦下）；
- Package 步骤从 LunarG 官方运行包（与 SDK 同为 1.4.357.0）取 x64 `vulkan-1.dll` 与许可证，与 exe 同目录分发；
- 新增 Verify 步骤：dumpbin 断言「exe 的非系统依赖恰好被随包 DLL 覆盖、且随包 DLL 自身不带 VC 运行库依赖」，缺件或退化直接失败（fail-closed）。

**`scripts/download.mjs`（开发机 / 本地构建同配方）**

- 同步构建参数与随包文件（`extraCopyPatterns`），安装后断言 `vulkan-1.dll`、`vcomp140.dll` 齐全；
- Windows 本地构建自动从 System32 复制 `vcomp140.dll`（缺件报错并提示安装官方 vc_redist）；
- 运行时标记升级为 `source:<ref>+r3+vk1.4.357.0`（随包 loader 的版本自动并入标记），已装旧配方的机器会自动重装。

**另含三个独立提交**：

- `4b753852`（fix）运行时配方标记并入 Vulkan loader 版本：升级 loader 时旧装机才会自动重装，不必再手动 bump 配方号；
- `6f032616`（docs）记录 `vcomp140.dll` 的来源与跟版更新责任——app-local 副本不随 Windows Update 更新，微软给 CRT/OpenMP 发安全更新时需跟版重建；
- `0f75bef6`（ci）修 WiX Toolset 的 PATH 写入——裸 `$GITHUB_PATH` 是未定义 PowerShell 变量，重定向静默失败，步骤一直显示成功但 WiX 其实不在 PATH。

## 验证

- CI 完整干跑（run 34709923062）8/8 job 全绿：四平台运行时打包（含新增 Windows 依赖断言）+ 四平台 app 构建（覆盖 download.mjs 的安装路径）；
- 干净 VM 端到端：把新构建的 win32-x64 运行时包拷进恢复干净的 Win10 LTSC（vc_redist 已卸载，System32 无任何 CRT 与 vulkan DLL），`parakeet-cli` exit 0 并输出 `no GPU found` 的 CPU 回退契约行；encode 428-518ms / decode 约 1.65ms，与旧构建（490-513ms / 1.68ms）持平（对照：关 OpenMP 的实验版本 encode 688-762ms / decode 25-203ms，正是弃用它的原因）；
- 同一 VM 里旧 6.12.1 二进制仍无法启动（对照组，确认 VM 确实处于「干净」状态）；
- 产物依赖终态（CI dumpbin 与本机 objdump 双向核对）：`parakeet-cli.exe` → `vulkan-1.dll` / `VCOMP140.DLL` / 系统 DLL；`vulkan-1.dll` → CFGMGR32 / KERNEL32 / ADVAPI32；`vcomp140.dll` → KERNEL32。

## 注意（需要重新执行 `yarn run download`）

运行时配方标记升级为 `r3+vk1.4.357.0`（随包 loader 的版本自动并入标记，将来升级 loader 不必再手动 bump 配方号），**已装过旧版的应用重新执行 `yarn run download` 会自动重装**（或等下次发版拉新包）。另外开发机在 Windows 上本地构建 whisper.cpp 时，现在要求系统装有 VC++ Redistributable（构建脚本要从 `System32\vcomp140.dll` 取该运行时，缺件会直接报错并给出安装提示）。

## 未验证

- 未在 VM 里装完整安装包走一遍应用内转录（应用侧代码未动，验证到 whisper 运行时 CLI 层）；
- macOS / Linux 产物本次仅确认正常构建打包；其动态库依赖为 `libvulkan.so.1`、`libgomp.so.1` 等发行版标配，不属于本修复范围。

## 数据库迁移

无新增或修改迁移。
