### PR TITLE
fix: whisper 异常退出时翻译退出码并探测缺失的运行库

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -88,6 +88,7 @@ preload 每次 `invoke` 生成一个 trace id，main 在 `registerRoute` 边界�
 | `PlaybackRepairService` | main | 播放修复任务收尾：`repair finished` / `repair cancelled` / `repair failed` / `repair task crashed`（含 `job: repair:<路径>`）——`job` 首尾成对靠这几条收尾闭环 |
 | `FfmpegServiceImpl` | main | 只记录网关看不到的任务体异常（`ffmpeg task failed`，含 `job`）；子进程失败与取消不在这里重复 |
 | `FfmpegGatewayImpl` | main | `spawned ffmpeg`（`job`/`pid`/`command`）、`FFmpeg 执行完成`、`FFmpeg 执行失败`（error，含 `exitCode`/`pid`/`stderrTail`）、`FFmpeg 已取消`（info）——子进程维度的唯一证据点 |
+| `WhisperCpp` | main | 识别子进程启停与异常退出：`spawned whisper.cpp parakeet-cli`、`whisper.cpp exited abnormally`（含 `exitCode` 与 NTSTATUS 退出码翻译后的 `hint`）、`whisper.cpp output rejected`、`whisper.cpp cancelled`、`whisper.cpp ran on CPU fallback` |
 | `SherpaOnnx` / `SherpaTts` | main | 识别/合成子进程启停与异常退出：`spawned sherpa-onnx`、`sherpa-onnx exited abnormally`、`sherpa-onnx output rejected`、`sherpa-onnx cancelled` |
 | `LocalTranscriptionService` | main | `transcription started`、分段识别重试与耗尽、`transcription done`/`transcription cancelled`/`transcription failed` 任务收尾（含 `elapsedMs`，done 另带 `chunkCount`/`srtPath`）——`job` 首尾成对靠这三条收尾闭环 |
 | `VideoLearningServiceImpl` | main | `clip trim started` / `clip ready` / 片段任务失败 |
@@ -245,7 +246,7 @@ grep -E '"message":"(log archived|log write failed)"' "$LATEST" | jq -c '{timest
 | 界面白屏、窗口打开即空 | `renderer did fail load`、`renderer preload error` | 看 `errorCode`、`validatedURL` |
 | 整个应用偶发闪退 | `render process gone` / `child process gone`，再往前 20 行看最后一条 info | 用 `runId` 限定本次会话 |
 | 字幕转录卡住不动 | `transcription started` 是否有、分段重试 warn、`long hold detected`（whisper 锁） | `grep '"job":"transcription:<路径>"'` |
-| 转录/转码报错但没有原因 | `FfmpegGatewayImpl` 的 `FFmpeg 执行失败`、`SherpaOnnx` 的 `sherpa-onnx exited abnormally` 的 `stderrTail` 数组 | `jq '.data.stderrTail'`，不要看 `error.message`（会被截断） |
+| 转录/转码报错但没有原因 | `FfmpegGatewayImpl` 的 `FFmpeg 执行失败`、`WhisperCpp` 的 `whisper.cpp exited abnormally`（`hint` 是退出码翻译，加载期失败时 `stderrTail` 为空）、`SherpaOnnx` 的 `sherpa-onnx exited abnormally` 的 `stderrTail` 数组 | `jq '.data.stderrTail'`，不要看 `error.message`（会被截断） |
 | 学习片段没生成 | `clip trim started` 有、`clip ready` 没有 → 中间失败；再查片段任务失败 error | `grep '"job":"clip:'` |
 | 提示没弹出来 / 状态没刷新 | `RendererEvents` 的 `renderer event dropped`（窗口销毁/不可用）与 `web contents destroyed` 对齐 | `grep -E 'renderer event dropped|web contents destroyed'` |
 | 操作很慢 | `ipc request completed` 的 `durationMs`；再看 `concurrency` 的 `wait passed` / `long hold detected` | 见 7.7、7.8 |

--- a/src/backend/infrastructure/media/whispercpp/WhisperCppCli.ts
+++ b/src/backend/infrastructure/media/whispercpp/WhisperCppCli.ts
@@ -33,6 +33,53 @@ export function detectGpuFallback(stderr: string): boolean {
     return GPU_FALLBACK_MARKERS.some((marker) => stderr.includes(marker));
 }
 
+/** Windows 随包运行库清单：与 release.yml / scripts/download.mjs 的打包契约一致，改随包清单要同步这里。 */
+const WINDOWS_RUNTIME_DLLS = ['vulkan-1.dll', 'vcomp140.dll'] as const;
+
+/**
+ * Windows NTSTATUS 异常退出码（8 位十六进制小写）→ 可读原因。
+ * parakeet-cli 在加载期失败时 stderr 为空，用户与日志能看到的只有裸退出码，必须翻译。
+ */
+const NTSTATUS_EXIT_REASONS: Record<string, string> = {
+    'c0000135': '缺少必需的 DLL（进程在加载期被系统终止）',
+    'c000007b': '映像格式错误（DLL 与系统架构不匹配或文件损坏）',
+    'c0000142': 'DLL 初始化失败',
+    'c000001d': '执行了非法指令（二进制损坏或 CPU 不支持）',
+    'c0000005': '内存访问冲突（程序内部错误）',
+};
+
+/** "找不到 DLL"类退出码：对它进一步探测引擎目录，指名报出缺失的随包文件。 */
+const DLL_NOT_FOUND_EXIT_CODE = 'c0000135';
+
+/**
+ * 把异常退出码翻译成可读原因与修复指引（Windows NTSTATUS 专用）。
+ *
+ * parakeet-cli 在加载期失败（如随包 DLL 被清理或损坏）时 stderr 为空，
+ * 只剩裸退出码可读；对"找不到 DLL"类退出码探测引擎目录，指名报出缺失的
+ * 随包文件。按"显式报错、不静默兜底"的约定只给修复指引，不自动补件。
+ *
+ * @param code 子进程退出码；Windows 上可能以无符号（3221225781）或有符号（-1073741515）出现。
+ * @param engineDir parakeet-cli 所在目录（随包 DLL 的落地位置）。
+ * @returns 可读诊断文本；非 NTSTATUS 退出码时返回 null，不猜测原因。
+ */
+export function describeAbnormalExit(code: number | null, engineDir: string): string | null {
+    if (code === null) return null;
+    const hex = (code >>> 0).toString(16).padStart(8, '0');
+    const reason = NTSTATUS_EXIT_REASONS[hex];
+    if (!reason) return null;
+    const parts = [`0x${hex.toUpperCase()} ${reason}`];
+    if (hex === DLL_NOT_FOUND_EXIT_CODE) {
+        const missing = WINDOWS_RUNTIME_DLLS.filter((name) => !fs.existsSync(path.join(engineDir, name)));
+        parts.push(
+            missing.length > 0
+                ? `引擎目录缺少 ${missing.join('、')}，可能被杀毒软件清理或安装不完整`
+                : '引擎目录里应用自带的运行库文件齐全，可能是文件损坏或被安全软件拦截'
+        );
+        parts.push('请重新安装应用');
+    }
+    return parts.join('；');
+}
+
 /**
  * whisper.cpp CLI 单次执行请求。
  */
@@ -186,16 +233,22 @@ export class WhisperCppCli {
                     }
                     if (code !== 0) {
                         const exitReason = signal ? `被信号 ${signal} 终止` : `退出码 ${code}`;
+                        // 加载期失败（如缺 DLL）时 stderr 为空，翻译后的原因让这条日志自身可读。
+                        const diagnosis = describeAbnormalExit(code, path.dirname(executablePath));
                         this.logger.error('whisper.cpp exited abnormally', {
                             job: request.job,
                             pid: child.pid,
                             exitCode: code,
                             signal,
+                            ...(diagnosis !== null && { hint: diagnosis }),
                             // 尾部行数组入日志，避免整段文本被单字段长度上限截掉关键原因。
                             stderrTail: tailLines(stderr, LOG_TAIL_LINES),
                             stdoutTail: tailLines(stdout, LOG_TAIL_LINES),
                         });
-                        reject(new Error(`whisper.cpp ${exitReason}：${stderr.slice(-2000)}`));
+                        // 诊断放在 stderr 之前：加载期失败时 stderr 为空，它是唯一可读的原因线索。
+                        const stderrText = stderr.slice(-2000).trim();
+                        const details = [diagnosis, stderrText].filter(Boolean).join('；');
+                        reject(new Error(`whisper.cpp ${exitReason}${details ? `：${details}` : ''}`));
                         return;
                     }
                     try {

--- a/src/backend/infrastructure/media/whispercpp/__tests__/WhisperCppCli.parse.test.ts
+++ b/src/backend/infrastructure/media/whispercpp/__tests__/WhisperCppCli.parse.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
-import { detectGpuFallback, parseWhisperCppOutput } from '@/backend/infrastructure/media/whispercpp/WhisperCppCli';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeAbnormalExit, detectGpuFallback, parseWhisperCppOutput } from '@/backend/infrastructure/media/whispercpp/WhisperCppCli';
 
 // 日志与运行时路径是系统边界：模块加载期会触达 Electron app，测试中静音并替换。
 vi.mock('@/backend/infrastructure/logger', () => ({
@@ -129,5 +132,53 @@ describe('核显回退检测', () => {
         const stderr = 'parakeet_backend_init: failed to initialize ACCEL backend';
 
         expect(detectGpuFallback(stderr)).toBe(false);
+    });
+});
+
+describe('异常退出诊断', () => {
+    let engineDir: string;
+
+    beforeEach(() => {
+        engineDir = fs.mkdtempSync(path.join(os.tmpdir(), 'whisper-exit-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(engineDir, { recursive: true, force: true });
+    });
+
+    it('引擎目录缺少随包 DLL 时点名缺失文件并给出修复指引', () => {
+        const diagnosis = describeAbnormalExit(3221225781, engineDir);
+
+        expect(diagnosis).toContain('0xC0000135');
+        expect(diagnosis).toContain('引擎目录缺少 vulkan-1.dll、vcomp140.dll');
+        expect(diagnosis).toContain('请重新安装应用');
+    });
+
+    it('随包 DLL 齐全时不误报缺失，提示文件可能损坏', () => {
+        fs.writeFileSync(path.join(engineDir, 'vulkan-1.dll'), 'stub');
+        fs.writeFileSync(path.join(engineDir, 'vcomp140.dll'), 'stub');
+
+        const diagnosis = describeAbnormalExit(3221225781, engineDir);
+
+        expect(diagnosis).toContain('运行库文件齐全');
+        expect(diagnosis).not.toContain('引擎目录缺少');
+    });
+
+    it('有符号表示的退出码同样能识别', () => {
+        // Node 在 Windows 上可能给有符号表示：-1073741515 即 0xC0000135
+        fs.writeFileSync(path.join(engineDir, 'vulkan-1.dll'), 'stub');
+        fs.writeFileSync(path.join(engineDir, 'vcomp140.dll'), 'stub');
+
+        expect(describeAbnormalExit(-1073741515, engineDir)).toContain('0xC0000135');
+    });
+
+    it('内存访问冲突等其他 NTSTATUS 退出码翻译为可读原因', () => {
+        expect(describeAbnormalExit(3221225477, engineDir)).toContain('内存访问冲突');
+        expect(describeAbnormalExit(3221225794, engineDir)).toContain('DLL 初始化失败');
+    });
+
+    it('普通退出码与信号终止不编造诊断', () => {
+        expect(describeAbnormalExit(134, engineDir)).toBeNull();
+        expect(describeAbnormalExit(null, engineDir)).toBeNull();
     });
 });


### PR DESCRIPTION
## 背景

来自 PR #268 评论第 3 条。whisper.cpp 转录失败时应用只抛出「whisper.cpp 退出码 3221225781：」——stderr 为空，用户和排障日志都读不出任何信息（当初排查 0xC0000135 就是被这一点拖慢的：只有一个裸退出码）。本次把 Windows NTSTATUS 退出码翻译成人话，并在「找不到 DLL」时探测引擎目录、指名报出缺失的随包文件。

## 改动

**`WhisperCppCli`**

- 新增 `describeAbnormalExit(code, engineDir)`：`0xC0000135`（缺 DLL）/`0xC0000142`（DLL 初始化失败）/`0xC000007B`（映像格式错误）/`0xC000001D`/`0xC0000005` 翻译为可读原因；无符号（3221225781）与有符号（-1073741515）表示都识别；
- 对 `0xC0000135` 探测引擎目录里的随包运行库（`vulkan-1.dll`、`vcomp140.dll`，与 release.yml / download.mjs 打包契约同一清单）：缺件则点名报出并给出重装指引；文件齐全时如实说明「可能损坏或被杀软拦截」，不误报缺失；
- 诊断文本进入两处：异常退出的错误消息（`TranscriptionService` 会把它写进任务状态，前端可见）与 `whisper.cpp exited abnormally` 日志的 `hint` 字段（JSONL 排障可见）；
- 非 NTSTATUS 退出码（Linux/macOS 的小整数、信号终止）不猜测原因，保持原行为。

按仓库约定只做显式报错 + 修复指引，不自动补件、不静默纠偏。

**`docs/observability.md`**

- 模块清单补 `WhisperCpp` 一行（原本缺失）；
- 症状表「转录/转码报错但没有原因」补充 `hint` 字段说明。

## 验证

- 新增 5 个单测（真实临时目录 + 真实文件探测，覆盖缺件点名、齐全不误报、有符号/无符号退出码、其他 NTSTATUS 翻译、普通退出码不编造），受影响测试文件 17/17 通过；
- 全量 `yarn test:run`：52 个测试文件通过（379 passed / 22 skipped，skip 为环境门控用例）；`npx tsc --noEmit` 全量通过；改动目录 `yarn lint` 通过（全量 lint 尚有 6 个既有 `react-hooks` 报错，均位于本次未触碰的前端文件，与本改动无关）；
- 消息到达路径人工核对：`WhisperCppCli.run` → `TranscriptionService`（`transcription failed` 日志 + 任务状态 `error.message`）→ 前端提示。

## 未验证

- 无法在 Linux 上造出真实的 Windows NTSTATUS 退出码（POSIX 退出码是 8 位），翻译与探测由单测覆盖，`run()` 内的消息组装未做端到端复现；
- 前端提示的实际展示效果未进界面走一遍（本次只改错误消息文本，未动 UI 代码）。

## 数据库迁移

无。
